### PR TITLE
Bootstrap Go CLI scaffolding for Orco

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Orco is a single-node orchestration engine that delivers most of the ergonomics of a modern orchestrator without the overhead of running a full Kubernetes control plane. It focuses on dependency-aware startup, health-gated restarts, structured logging, and progressive rollout strategies for services defined in a declarative `stack.yaml` file.
 
+## Getting started
+
+The repository now includes a Go implementation of the Orco CLI. To experiment with the parser and planning utilities:
+
+1. Build the binary: `go build ./cmd/orco`
+2. Run commands against the sample manifest in `examples/demo-stack.yaml`, for example:
+
+   ```bash
+   ./orco --file examples/demo-stack.yaml status
+   ./orco --file examples/demo-stack.yaml graph --dot
+   ./orco --file examples/demo-stack.yaml up
+   ```
+
+These commands currently validate the stack definition, construct the dependency DAG, and display planning information while the execution engine is developed. Future work will add real runtimes, health gating, and supervisors on top of this foundation.
+
 ## Problem statement
 
 Traditional tooling such as `docker-compose` is optimized for "bring up these services" but leaves orchestration concerns to operators. This leads to awkward limitations:

--- a/cmd/orco/main.go
+++ b/cmd/orco/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/example/orco/internal/cli"
+
+func main() {
+	cli.Execute()
+}

--- a/examples/demo-stack.yaml
+++ b/examples/demo-stack.yaml
@@ -1,0 +1,71 @@
+version: 0.1
+
+stack:
+  name: demo
+  workdir: ./
+
+defaults:
+  restartPolicy:
+    maxRetries: 5
+    backoff:
+      min: 1s
+      max: 30s
+      factor: 2.0
+  health:
+    gracePeriod: 5s
+    interval: 2s
+    timeout: 1s
+    failureThreshold: 3
+
+services:
+  db:
+    image: postgres:16
+    runtime: docker
+    env:
+      POSTGRES_PASSWORD: example
+    ports: ["5432:5432"]
+    health:
+      http:
+        url: http://localhost:5432/healthz
+        expectStatus: [200, 204]
+    update:
+      strategy: rolling
+      maxUnavailable: 0
+      maxSurge: 1
+    replicas: 1
+
+  api:
+    image: ghcr.io/acme/api:latest
+    runtime: docker
+    envFromFile: ./secrets/api.env
+    dependsOn:
+      - target: db
+        require: ready
+        timeout: 60s
+    health:
+      http:
+        url: http://localhost:8080/health
+        expectStatus: [200]
+    ports: ["8080:8080"]
+    replicas: 2
+    restartPolicy:
+      maxRetries: 10
+      backoff:
+        min: 500ms
+        max: 20s
+        factor: 1.8
+
+  web:
+    runtime: process
+    command: ["./web", "--port=3000"]
+    env:
+      API_URL: http://localhost:8080
+    dependsOn:
+      - target: api
+        require: ready
+    health:
+      http:
+        url: http://localhost:3000/healthz
+        expectStatus: [200]
+    ports: ["3000:3000"]
+    replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/example/orco
+
+go 1.24.3
+
+require (
+	github.com/spf13/cobra v1.7.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newApplyCmd(ctx *context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Reconcile stack changes (planned)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Apply is not yet implemented. Stack %s parsed successfully.\n", doc.File.Stack.Name)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newDownCmd(ctx *context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "down",
+		Short: "Plan stack shutdown in reverse dependency order",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+			order := doc.Graph.Services()
+			fmt.Fprintf(cmd.OutOrStdout(), "Shutdown order for stack %s:\n", doc.File.Stack.Name)
+			for i := len(order) - 1; i >= 0; i-- {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s\n", len(order)-i, order[i])
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Process orchestration is forthcoming; down currently reports the planned order.")
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newGraphCmd(ctx *context) *cobra.Command {
+	var dot bool
+	cmd := &cobra.Command{
+		Use:   "graph",
+		Short: "Render the dependency graph",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+			if dot {
+				fmt.Fprint(cmd.OutOrStdout(), doc.Graph.DOT())
+				return nil
+			}
+			var b strings.Builder
+			for _, svc := range doc.Graph.Services() {
+				deps := doc.File.Services[svc].DependsOn
+				if len(deps) == 0 {
+					fmt.Fprintf(&b, "%s\n", svc)
+					continue
+				}
+				fmt.Fprintf(&b, "%s -> ", svc)
+				names := make([]string, len(deps))
+				for i, dep := range deps {
+					names[i] = dep.Target
+				}
+				fmt.Fprintf(&b, "%s\n", strings.Join(names, ", "))
+			}
+			fmt.Fprint(cmd.OutOrStdout(), b.String())
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&dot, "dot", false, "Render in Graphviz DOT format")
+	return cmd
+}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newLogsCmd(ctx *context) *cobra.Command {
+	var follow bool
+	cmd := &cobra.Command{
+		Use:   "logs [service]",
+		Short: "Tail structured logs (planned)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+			target := "all services"
+			if len(args) == 1 {
+				target = args[0]
+				if _, ok := doc.File.Services[target]; !ok {
+					return fmt.Errorf("unknown service %s", target)
+				}
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Log streaming for %s is not yet implemented. Planned follow=%t\n", target, follow)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log output")
+	return cmd
+}

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newRestartCmd(ctx *context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restart [service]",
+		Short: "Plan a rolling restart of the specified service",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+			svcName := args[0]
+			svc, ok := doc.File.Services[svcName]
+			if !ok {
+				return fmt.Errorf("unknown service %s", svcName)
+			}
+			strategy := "rolling"
+			if svc.Update != nil && svc.Update.Strategy != "" {
+				strategy = svc.Update.Strategy
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Planned restart for %s (strategy=%s, replicas=%d). Implementation pending.\n", svcName, strategy, svc.Replicas)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// NewRootCmd constructs the root command.
+func NewRootCmd() *cobra.Command {
+	var stackFile string
+
+	root := &cobra.Command{
+		Use:   "orco",
+		Short: "Single-node orchestration engine",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	root.PersistentFlags().StringVarP(&stackFile, "file", "f", "stack.yaml", "Path to stack definition")
+
+	ctx := &context{stackFile: &stackFile}
+	root.AddCommand(newUpCmd(ctx))
+	root.AddCommand(newDownCmd(ctx))
+	root.AddCommand(newStatusCmd(ctx))
+	root.AddCommand(newLogsCmd(ctx))
+	root.AddCommand(newGraphCmd(ctx))
+	root.AddCommand(newRestartCmd(ctx))
+	root.AddCommand(newApplyCmd(ctx))
+
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	return root
+}
+
+// Execute runs the CLI entrypoint.
+func Execute() {
+	if err := NewRootCmd().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+type context struct {
+	stackFile *string
+}
+
+func (c *context) loadStack() (*stackDocument, error) {
+	return loadStackFromFile(*c.stackFile)
+}

--- a/internal/cli/stack.go
+++ b/internal/cli/stack.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/example/orco/internal/engine"
+	"github.com/example/orco/internal/stack"
+)
+
+type stackDocument struct {
+	File   *stack.StackFile
+	Graph  *engine.Graph
+	Source string
+}
+
+func loadStackFromFile(path string) (*stackDocument, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open stack file: %w", err)
+	}
+	defer f.Close()
+
+	doc, err := stack.Parse(f)
+	if err != nil {
+		return nil, err
+	}
+	graph, err := engine.BuildGraph(doc)
+	if err != nil {
+		return nil, err
+	}
+	return &stackDocument{File: doc, Graph: graph, Source: path}, nil
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newStatusCmd(ctx *context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Display a summary of services defined in the stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "SERVICE\tRUNTIME\tREPLICAS\tDEPENDENCIES")
+			for _, name := range doc.File.ServicesSorted() {
+				svc := doc.File.Services[name]
+				deps := "-"
+				if len(svc.DependsOn) > 0 {
+					items := make([]string, len(svc.DependsOn))
+					for i, dep := range svc.DependsOn {
+						require := dep.Require
+						if require == "" {
+							require = "ready"
+						}
+						items[i] = fmt.Sprintf("%s(%s)", dep.Target, require)
+					}
+					deps = strings.Join(items, ", ")
+				}
+				fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", name, svc.Runtime, svc.Replicas, deps)
+			}
+			w.Flush()
+			fmt.Fprintf(cmd.OutOrStdout(), "\nStack: %s (version %s)\n", doc.File.Stack.Name, doc.File.Version)
+			fmt.Fprintf(cmd.OutOrStdout(), "Validated at %s\n", time.Now().Format(time.RFC3339))
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newUpCmd(ctx *context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "up",
+		Short: "Validate the stack and prepare services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Stack %s loaded from %s\n", doc.File.Stack.Name, doc.Source)
+			fmt.Fprintln(cmd.OutOrStdout(), "Startup order:")
+			for i, svc := range doc.Graph.Services() {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s\n", i+1, svc)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Runtime orchestration is not yet implemented; this command currently performs validation and planning only.")
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/engine/dag.go
+++ b/internal/engine/dag.go
@@ -1,0 +1,169 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/example/orco/internal/stack"
+)
+
+// Graph represents service dependencies.
+type Graph struct {
+	services map[string]*stack.Service
+	edges    map[string][]string
+	reverse  map[string][]string
+	order    []string
+}
+
+// BuildGraph constructs the dependency graph and validates acyclicity.
+func BuildGraph(doc *stack.StackFile) (*Graph, error) {
+	g := &Graph{
+		services: make(map[string]*stack.Service, len(doc.Services)),
+		edges:    make(map[string][]string, len(doc.Services)),
+		reverse:  make(map[string][]string, len(doc.Services)),
+	}
+	for name, svc := range doc.Services {
+		g.services[name] = svc
+		if _, ok := g.edges[name]; !ok {
+			g.edges[name] = nil
+		}
+		for _, dep := range svc.DependsOn {
+			g.edges[name] = append(g.edges[name], dep.Target)
+			g.reverse[dep.Target] = append(g.reverse[dep.Target], name)
+			if _, ok := g.edges[dep.Target]; !ok {
+				g.edges[dep.Target] = nil
+			}
+		}
+	}
+
+	order, err := topoSort(g.edges)
+	if err != nil {
+		return nil, err
+	}
+	g.order = order
+	return g, nil
+}
+
+// Services returns service names in topological order.
+func (g *Graph) Services() []string {
+	out := make([]string, len(g.order))
+	copy(out, g.order)
+	return out
+}
+
+// Dependents returns services that depend on the provided service.
+func (g *Graph) Dependents(name string) []string {
+	deps := g.reverse[name]
+	out := make([]string, len(deps))
+	copy(out, deps)
+	return out
+}
+
+// DOT renders the graph in Graphviz dot format.
+func (g *Graph) DOT() string {
+	var b strings.Builder
+	b.WriteString("digraph orco {\n")
+	for svc := range g.services {
+		b.WriteString(fmt.Sprintf("  \"%s\";\n", svc))
+	}
+	for from, tos := range g.edges {
+		for _, to := range tos {
+			b.WriteString(fmt.Sprintf("  \"%s\" -> \"%s\";\n", from, to))
+		}
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func topoSort(edges map[string][]string) ([]string, error) {
+	indegree := make(map[string]int)
+	for from := range edges {
+		if _, ok := indegree[from]; !ok {
+			indegree[from] = 0
+		}
+		for _, to := range edges[from] {
+			indegree[to]++
+		}
+	}
+	queue := make([]string, 0, len(indegree))
+	for node, deg := range indegree {
+		if deg == 0 {
+			queue = append(queue, node)
+		}
+	}
+	order := make([]string, 0, len(indegree))
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		order = append(order, node)
+		for _, dep := range edges[node] {
+			indegree[dep]--
+			if indegree[dep] == 0 {
+				queue = append(queue, dep)
+			}
+		}
+	}
+	if len(order) != len(indegree) {
+		cycle := detectCycle(edges)
+		return nil, fmt.Errorf("dependency cycle detected: %s", strings.Join(cycle, " -> "))
+	}
+	return order, nil
+}
+
+func detectCycle(edges map[string][]string) []string {
+	visited := make(map[string]bool)
+	stack := make([]string, 0)
+
+	var dfs func(string) []string
+	dfs = func(node string) []string {
+		visited[node] = true
+		stack = append(stack, node)
+		for _, next := range edges[node] {
+			onStack := false
+			for _, cur := range stack {
+				if cur == next {
+					onStack = true
+					break
+				}
+			}
+			if onStack {
+				return appendStack(stack, next)
+			}
+			if !visited[next] {
+				if cycle := dfs(next); cycle != nil {
+					return cycle
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		return nil
+	}
+
+	for node := range edges {
+		if !visited[node] {
+			if cycle := dfs(node); cycle != nil {
+				return cycle
+			}
+		}
+	}
+	return nil
+}
+
+func appendStack(stack []string, target string) []string {
+	idx := -1
+	for i, node := range stack {
+		if node == target {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return nil
+	}
+	out := make([]string, 0, len(stack)-idx+1)
+	for i := idx; i < len(stack); i++ {
+		out = append(out, stack[i])
+	}
+	out = append(out, target)
+	return out
+}

--- a/internal/stack/parser.go
+++ b/internal/stack/parser.go
@@ -1,0 +1,139 @@
+package stack
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Parse reads a stack definition from YAML.
+func Parse(r io.Reader) (*StackFile, error) {
+	decoder := yaml.NewDecoder(r)
+	decoder.KnownFields(true)
+	var doc StackFile
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("decode stack: %w", err)
+	}
+	if err := doc.ApplyDefaults(); err != nil {
+		return nil, err
+	}
+	if err := doc.Validate(); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+// ApplyDefaults merges stack defaults onto services.
+func (s *StackFile) ApplyDefaults() error {
+	for name, svc := range s.Services {
+		if svc == nil {
+			return fmt.Errorf("service %q is null", name)
+		}
+		if svc.Replicas == 0 {
+			svc.Replicas = 1
+		}
+		if svc.Runtime == "" {
+			svc.Runtime = "docker"
+		}
+		if svc.RestartPolicy == nil && s.Defaults.RestartPolicy != nil {
+			svc.RestartPolicy = s.Defaults.RestartPolicy.Clone()
+		}
+		if svc.Health == nil && s.Defaults.Health != nil {
+			svc.Health = s.Defaults.Health.Clone()
+		}
+	}
+	return nil
+}
+
+// Validate enforces schema invariants.
+func (s *StackFile) Validate() error {
+	if s.Version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if len(s.Services) == 0 {
+		return fmt.Errorf("at least one service must be defined")
+	}
+	if s.Stack.Name == "" {
+		return fmt.Errorf("stack.name is required")
+	}
+	for name, svc := range s.Services {
+		if svc.Runtime == "" {
+			return fmt.Errorf("service %s missing runtime", name)
+		}
+		if svc.Health != nil {
+			if err := validateHealth(name, svc.Health); err != nil {
+				return err
+			}
+		}
+		if svc.Replicas < 1 {
+			return fmt.Errorf("service %s must have at least one replica", name)
+		}
+		if svc.RestartPolicy != nil && svc.RestartPolicy.Backoff != nil {
+			if svc.RestartPolicy.Backoff.Factor == 0 {
+				return fmt.Errorf("service %s backoff factor must be non-zero", name)
+			}
+		}
+		for i, dep := range svc.DependsOn {
+			if dep.Target == "" {
+				return fmt.Errorf("service %s dependency %d missing target", name, i)
+			}
+			switch dep.Require {
+			case "", "ready", "started", "exists":
+			default:
+				return fmt.Errorf("service %s dependency %s has invalid require=%s", name, dep.Target, dep.Require)
+			}
+			if _, ok := s.Services[dep.Target]; !ok {
+				return fmt.Errorf("service %s dependency %s references unknown service", name, dep.Target)
+			}
+		}
+	}
+	return nil
+}
+
+func validateHealth(name string, h *Health) error {
+	probes := 0
+	if h.HTTP != nil {
+		probes++
+	}
+	if h.TCP != nil {
+		probes++
+	}
+	if h.Command != nil {
+		probes++
+	}
+	if probes > 1 {
+		return fmt.Errorf("service %s defines multiple probe types; only one supported in v0.1", name)
+	}
+	if probes == 0 {
+		return fmt.Errorf("service %s health block present but no probe configured", name)
+	}
+	if h.FailureThreshold == 0 {
+		h.FailureThreshold = 3
+	}
+	if h.Interval.Duration == 0 {
+		h.Interval.Duration = 2 * time.Second
+	}
+	if h.Timeout.Duration == 0 {
+		h.Timeout.Duration = time.Second
+	}
+	if h.GracePeriod.Duration == 0 {
+		h.GracePeriod.Duration = 5 * time.Second
+	}
+	if h.SuccessThreshold == 0 {
+		h.SuccessThreshold = 1
+	}
+	return nil
+}
+
+// ServicesSorted returns service names sorted alphabetically.
+func (s *StackFile) ServicesSorted() []string {
+	out := make([]string, 0, len(s.Services))
+	for name := range s.Services {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/stack/types.go
+++ b/internal/stack/types.go
@@ -1,0 +1,201 @@
+package stack
+
+import (
+	"fmt"
+	"time"
+)
+
+// Duration wraps time.Duration for YAML unmarshalling.
+type Duration struct {
+	time.Duration
+}
+
+// UnmarshalText parses a textual duration, accepting empty strings.
+func (d *Duration) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		d.Duration = 0
+		return nil
+	}
+	dur, err := time.ParseDuration(string(text))
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", string(text), err)
+	}
+	d.Duration = dur
+	return nil
+}
+
+// MarshalText renders the duration using time.Duration formatting.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.Duration.String()), nil
+}
+
+// StackFile represents the contents of stack.yaml.
+type StackFile struct {
+	Version  string     `yaml:"version"`
+	Stack    StackMeta  `yaml:"stack"`
+	Defaults Defaults   `yaml:"defaults"`
+	Services ServiceMap `yaml:"services"`
+}
+
+// StackMeta contains metadata about the stack itself.
+type StackMeta struct {
+	Name    string `yaml:"name"`
+	Workdir string `yaml:"workdir"`
+}
+
+// Defaults defines global defaults applied to services.
+type Defaults struct {
+	RestartPolicy *RestartPolicy `yaml:"restartPolicy"`
+	Health        *Health        `yaml:"health"`
+}
+
+// ServiceMap is a map keyed by service name.
+type ServiceMap map[string]*Service
+
+// Service describes an individual runnable unit.
+type Service struct {
+	Image         string            `yaml:"image"`
+	Runtime       string            `yaml:"runtime"`
+	Command       []string          `yaml:"command"`
+	Env           map[string]string `yaml:"env"`
+	EnvFromFile   string            `yaml:"envFromFile"`
+	Ports         []string          `yaml:"ports"`
+	DependsOn     []Dependency      `yaml:"dependsOn"`
+	Health        *Health           `yaml:"health"`
+	Update        *UpdatePolicy     `yaml:"update"`
+	Replicas      int               `yaml:"replicas"`
+	RestartPolicy *RestartPolicy    `yaml:"restartPolicy"`
+}
+
+// Dependency defines an edge in the service DAG.
+type Dependency struct {
+	Target  string   `yaml:"target"`
+	Require string   `yaml:"require"`
+	Timeout Duration `yaml:"timeout"`
+}
+
+// Health describes the health checking configuration.
+type Health struct {
+	GracePeriod      Duration      `yaml:"gracePeriod"`
+	Interval         Duration      `yaml:"interval"`
+	Timeout          Duration      `yaml:"timeout"`
+	FailureThreshold int           `yaml:"failureThreshold"`
+	SuccessThreshold int           `yaml:"successThreshold"`
+	HTTP             *HTTPProbe    `yaml:"http"`
+	TCP              *TCPProbe     `yaml:"tcp"`
+	Command          *CommandProbe `yaml:"cmd"`
+}
+
+// HTTPProbe defines readiness detection via HTTP.
+type HTTPProbe struct {
+	URL          string `yaml:"url"`
+	ExpectStatus []int  `yaml:"expectStatus"`
+}
+
+// TCPProbe defines readiness detection via TCP dial.
+type TCPProbe struct {
+	Address string `yaml:"address"`
+}
+
+// CommandProbe executes a command as a readiness probe.
+type CommandProbe struct {
+	Command []string `yaml:"command"`
+	Timeout Duration `yaml:"timeout"`
+}
+
+// UpdatePolicy controls rolling update parameters.
+type UpdatePolicy struct {
+	Strategy       string `yaml:"strategy"`
+	MaxUnavailable int    `yaml:"maxUnavailable"`
+	MaxSurge       int    `yaml:"maxSurge"`
+}
+
+// RestartPolicy controls restart behavior.
+type RestartPolicy struct {
+	MaxRetries int      `yaml:"maxRetries"`
+	Backoff    *Backoff `yaml:"backoff"`
+}
+
+// Backoff describes exponential backoff configuration.
+type Backoff struct {
+	Min    Duration `yaml:"min"`
+	Max    Duration `yaml:"max"`
+	Factor float64  `yaml:"factor"`
+}
+
+// Clone creates a deep copy of the service.
+func (s *Service) Clone() *Service {
+	if s == nil {
+		return nil
+	}
+	cp := *s
+	if s.Env != nil {
+		cp.Env = make(map[string]string, len(s.Env))
+		for k, v := range s.Env {
+			cp.Env[k] = v
+		}
+	}
+	if s.Command != nil {
+		cp.Command = append([]string(nil), s.Command...)
+	}
+	if s.Ports != nil {
+		cp.Ports = append([]string(nil), s.Ports...)
+	}
+	if s.DependsOn != nil {
+		cp.DependsOn = append([]Dependency(nil), s.DependsOn...)
+	}
+	if s.Health != nil {
+		cp.Health = s.Health.Clone()
+	}
+	if s.Update != nil {
+		cp.Update = &UpdatePolicy{
+			Strategy:       s.Update.Strategy,
+			MaxUnavailable: s.Update.MaxUnavailable,
+			MaxSurge:       s.Update.MaxSurge,
+		}
+	}
+	if s.RestartPolicy != nil {
+		cp.RestartPolicy = s.RestartPolicy.Clone()
+	}
+	return &cp
+}
+
+// Clone creates a deep copy of the health configuration.
+func (h *Health) Clone() *Health {
+	if h == nil {
+		return nil
+	}
+	cp := *h
+	if h.HTTP != nil {
+		httpCopy := *h.HTTP
+		cp.HTTP = &httpCopy
+		if h.HTTP.ExpectStatus != nil {
+			cp.HTTP.ExpectStatus = append([]int(nil), h.HTTP.ExpectStatus...)
+		}
+	}
+	if h.TCP != nil {
+		tcpCopy := *h.TCP
+		cp.TCP = &tcpCopy
+	}
+	if h.Command != nil {
+		cmdCopy := *h.Command
+		if h.Command.Command != nil {
+			cmdCopy.Command = append([]string(nil), h.Command.Command...)
+		}
+		cp.Command = &cmdCopy
+	}
+	return &cp
+}
+
+// Clone creates a deep copy of the restart policy.
+func (r *RestartPolicy) Clone() *RestartPolicy {
+	if r == nil {
+		return nil
+	}
+	cp := *r
+	if r.Backoff != nil {
+		backoffCopy := *r.Backoff
+		cp.Backoff = &backoffCopy
+	}
+	return &cp
+}


### PR DESCRIPTION
## Summary
- add a Go module that defines the initial stack schema, parser, and dependency DAG builder
- scaffold a Cobra-based CLI with planning-oriented commands for up/down/status/logs/graph/restart/apply
- document how to build and try the CLI and ship an example stack manifest

## Testing
- `go build ./cmd/orco`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68def45a8e7c8325ae9c85163e0d9003