### PR TITLE
Update Go module to supported toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/example/orco
 
-go 1.24.3
+go 1.21
 
 require (
 	github.com/spf13/cobra v1.7.0


### PR DESCRIPTION
## Summary
- update the module's `go` directive to the supported Go 1.21 release
- tidy the module to ensure metadata stays consistent

## Testing
- go mod tidy

------
https://chatgpt.com/codex/tasks/task_e_68df03607094832582e97916476f2cbc