### PR TITLE
Validate service runtime options

### DIFF
--- a/internal/stack/parser.go
+++ b/internal/stack/parser.go
@@ -63,6 +63,9 @@ func (s *StackFile) Validate() error {
 		if svc.Runtime == "" {
 			return fmt.Errorf("service %s missing runtime", name)
 		}
+		if svc.Runtime != "docker" && svc.Runtime != "process" {
+			return fmt.Errorf("service %s has unsupported runtime %q", name, svc.Runtime)
+		}
 		if svc.Health != nil {
 			if err := validateHealth(name, svc.Health); err != nil {
 				return err

--- a/internal/stack/parser_test.go
+++ b/internal/stack/parser_test.go
@@ -1,0 +1,47 @@
+package stack
+
+import "testing"
+
+func TestStackFileValidateAcceptsSupportedRuntimes(t *testing.T) {
+	tests := map[string]string{
+		"docker":  "docker",
+		"process": "process",
+	}
+
+	for name, runtime := range tests {
+		t.Run(name, func(t *testing.T) {
+			sf := StackFile{
+				Version: "0.1",
+				Stack:   StackMeta{Name: "test"},
+				Services: ServiceMap{
+					"app": {
+						Runtime:  runtime,
+						Replicas: 1,
+					},
+				},
+			}
+
+			if err := sf.Validate(); err != nil {
+				t.Fatalf("expected runtime %s to be accepted, got error: %v", runtime, err)
+			}
+		})
+	}
+}
+
+func TestStackFileValidateRejectsUnsupportedRuntime(t *testing.T) {
+	sf := StackFile{
+		Version: "0.1",
+		Stack:   StackMeta{Name: "test"},
+		Services: ServiceMap{
+			"app": {
+				Runtime:  "unsupported",
+				Replicas: 1,
+			},
+		},
+	}
+
+	err := sf.Validate()
+	if err == nil {
+		t.Fatalf("expected error for unsupported runtime")
+	}
+}


### PR DESCRIPTION
## Summary
- restrict stack service runtime validation to docker and process
- add unit tests covering supported and unsupported runtime options

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df0360b3b88325bf9af710e20c5fa4