### PR TITLE
Implement orchestrator runtime execution and CLI integration

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/example/orco/internal/engine"
+	"github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/runtime/docker"
+	"github.com/example/orco/internal/runtime/process"
 )
 
 // NewRootCmd constructs the root command.
@@ -45,9 +50,20 @@ func Execute() {
 }
 
 type context struct {
-	stackFile *string
+	stackFile    *string
+	orchestrator *engine.Orchestrator
 }
 
 func (c *context) loadStack() (*stackDocument, error) {
 	return loadStackFromFile(*c.stackFile)
+}
+
+func (c *context) getOrchestrator() *engine.Orchestrator {
+	if c.orchestrator == nil {
+		c.orchestrator = engine.NewOrchestrator(runtime.Registry{
+			"docker":  docker.New(),
+			"process": process.New(),
+		})
+	}
+	return c.orchestrator
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1,28 +1,90 @@
 package cli
 
 import (
+	stdcontext "context"
 	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/example/orco/internal/engine"
 )
 
 func newUpCmd(ctx *context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "up",
-		Short: "Validate the stack and prepare services",
+		Short: "Start services defined in the stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			doc, err := ctx.loadStack()
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Stack %s loaded from %s\n", doc.File.Stack.Name, doc.Source)
-			fmt.Fprintln(cmd.OutOrStdout(), "Startup order:")
-			for i, svc := range doc.Graph.Services() {
-				fmt.Fprintf(cmd.OutOrStdout(), "  %d. %s\n", i+1, svc)
+
+			events := make(chan engine.Event, 64)
+			var printer sync.WaitGroup
+			printer.Add(1)
+			go func() {
+				defer printer.Done()
+				printEvents(cmd.OutOrStdout(), cmd.ErrOrStderr(), events)
+			}()
+			defer func() {
+				close(events)
+				printer.Wait()
+			}()
+
+			orch := ctx.getOrchestrator()
+			deployment, err := orch.Up(cmd.Context(), doc.File, doc.Graph, events)
+			if err != nil {
+				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "Runtime orchestration is not yet implemented; this command currently performs validation and planning only.")
+
+			fmt.Fprintln(cmd.OutOrStdout(), "All services reported ready.")
+
+			stopCtx, cancel := stdcontext.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			if err := deployment.Stop(stopCtx, events); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Services shut down cleanly.")
 			return nil
 		},
 	}
 	return cmd
+}
+
+func printEvents(stdout, stderr io.Writer, events <-chan engine.Event) {
+	for event := range events {
+		switch event.Type {
+		case engine.EventTypeLog:
+			fmt.Fprintf(stdout, "[%s] %s\n", event.Service, event.Message)
+		case engine.EventTypeError:
+			if event.Err != nil {
+				fmt.Fprintf(stderr, "error: %s %s: %v\n", event.Service, event.Message, event.Err)
+			} else {
+				fmt.Fprintf(stderr, "error: %s %s\n", event.Service, event.Message)
+			}
+		default:
+			label := formatEventType(event.Type)
+			if event.Message != "" {
+				fmt.Fprintf(stdout, "%s %s: %s\n", label, event.Service, event.Message)
+			} else {
+				fmt.Fprintf(stdout, "%s %s\n", label, event.Service)
+			}
+		}
+	}
+}
+
+func formatEventType(t engine.EventType) string {
+	s := string(t)
+	if s == "" {
+		return ""
+	}
+	if len(s) == 1 {
+		return strings.ToUpper(s)
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/internal/cli/up_integration_test.go
+++ b/internal/cli/up_integration_test.go
@@ -1,0 +1,287 @@
+package cli
+
+import (
+	"bytes"
+	stdcontext "context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/example/orco/internal/engine"
+	"github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/stack"
+)
+
+func TestUpCommandStartsServicesInDependencyOrder(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+	rt.logs["db"] = []string{"database online"}
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+services:
+  db:
+    runtime: process
+    command: ["sleep", "0"]
+  api:
+    runtime: process
+    command: ["sleep", "0"]
+    dependsOn:
+      - target: db
+  worker:
+    runtime: process
+    command: ["sleep", "0"]
+    dependsOn:
+      - target: api
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
+	}
+
+	cmd := newUpCmd(ctx)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("up command failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	expectedStart := []string{"db", "api", "worker"}
+	if !reflect.DeepEqual(rt.startOrder(), expectedStart) {
+		t.Fatalf("unexpected start order: got %v want %v", rt.startOrder(), expectedStart)
+	}
+	if !reflect.DeepEqual(rt.readyOrder(), expectedStart) {
+		t.Fatalf("unexpected ready order: got %v want %v", rt.readyOrder(), expectedStart)
+	}
+	expectedStop := []string{"worker", "api", "db"}
+	if !reflect.DeepEqual(rt.stopOrder(), expectedStop) {
+		t.Fatalf("unexpected stop order: got %v want %v", rt.stopOrder(), expectedStop)
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte("All services reported ready.")) {
+		t.Fatalf("expected readiness message in stdout, got: %s", stdout.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("Services shut down cleanly.")) {
+		t.Fatalf("expected shutdown message in stdout, got: %s", stdout.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("[db] database online")) {
+		t.Fatalf("expected log output in stdout, got: %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got: %s", stderr.String())
+	}
+}
+
+func TestUpCommandPropagatesRuntimeErrors(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+	rt.waitErr["api"] = errors.New("not healthy")
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+services:
+  db:
+    runtime: process
+    command: ["sleep", "0"]
+  api:
+    runtime: process
+    command: ["sleep", "0"]
+    dependsOn:
+      - target: db
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
+	}
+
+	cmd := newUpCmd(ctx)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected command to fail due to readiness error")
+	}
+
+	expectedStart := []string{"db", "api"}
+	if !reflect.DeepEqual(rt.startOrder(), expectedStart) {
+		t.Fatalf("unexpected start order: got %v want %v", rt.startOrder(), expectedStart)
+	}
+	if !reflect.DeepEqual(rt.readyOrder(), []string{"db"}) {
+		t.Fatalf("unexpected ready order: got %v want %v", rt.readyOrder(), []string{"db"})
+	}
+	expectedStop := []string{"api", "db"}
+	if !reflect.DeepEqual(rt.stopOrder(), expectedStop) {
+		t.Fatalf("unexpected stop order: got %v want %v", rt.stopOrder(), expectedStop)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("error: api readiness failed")) {
+		t.Fatalf("expected readiness error in stderr, got: %s", stderr.String())
+	}
+}
+
+func writeStackFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write stack file: %v", err)
+	}
+	return path
+}
+
+type mockRuntime struct {
+	mu        sync.Mutex
+	starts    []string
+	readies   []string
+	stops     []string
+	readyCh   map[string]chan struct{}
+	startErr  map[string]error
+	waitErr   map[string]error
+	stopErr   map[string]error
+	logs      map[string][]string
+	autoReady bool
+}
+
+func newMockRuntime() *mockRuntime {
+	return &mockRuntime{
+		readyCh:   make(map[string]chan struct{}),
+		startErr:  make(map[string]error),
+		waitErr:   make(map[string]error),
+		stopErr:   make(map[string]error),
+		logs:      make(map[string][]string),
+		autoReady: true,
+	}
+}
+
+func (m *mockRuntime) Start(ctx stdcontext.Context, name string, svc *stack.Service) (runtime.Instance, error) {
+	m.mu.Lock()
+	if err := m.startErr[name]; err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	m.starts = append(m.starts, name)
+	readyCh := make(chan struct{})
+	m.readyCh[name] = readyCh
+	waitErr := m.waitErr[name]
+	stopErr := m.stopErr[name]
+	logLines := append([]string(nil), m.logs[name]...)
+	autoReady := m.autoReady
+	m.mu.Unlock()
+
+	logsCh := make(chan string, len(logLines))
+	for _, line := range logLines {
+		logsCh <- line
+	}
+
+	inst := &mockInstance{
+		runtime: m,
+		name:    name,
+		ready:   readyCh,
+		logs:    logsCh,
+		waitErr: waitErr,
+		stopErr: stopErr,
+	}
+
+	if autoReady {
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			m.SignalReady(name)
+		}()
+	}
+
+	return inst, nil
+}
+
+func (m *mockRuntime) SignalReady(name string) {
+	m.mu.Lock()
+	ch, ok := m.readyCh[name]
+	if ok {
+		delete(m.readyCh, name)
+	}
+	m.mu.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+func (m *mockRuntime) recordReady(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.readies = append(m.readies, name)
+}
+
+func (m *mockRuntime) recordStop(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stops = append(m.stops, name)
+}
+
+func (m *mockRuntime) startOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.starts...)
+}
+
+func (m *mockRuntime) readyOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.readies...)
+}
+
+func (m *mockRuntime) stopOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.stops...)
+}
+
+type mockInstance struct {
+	runtime  *mockRuntime
+	name     string
+	ready    chan struct{}
+	logs     chan string
+	waitErr  error
+	stopErr  error
+	stopOnce sync.Once
+}
+
+func (i *mockInstance) WaitReady(ctx stdcontext.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-i.ready:
+		if i.waitErr != nil {
+			return i.waitErr
+		}
+		i.runtime.recordReady(i.name)
+		return nil
+	}
+}
+
+func (i *mockInstance) Stop(ctx stdcontext.Context) error {
+	var err error
+	i.stopOnce.Do(func() {
+		i.runtime.recordStop(i.name)
+		close(i.logs)
+		err = i.stopErr
+	})
+	return err
+}
+
+func (i *mockInstance) Logs() <-chan string {
+	return i.logs
+}

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -1,0 +1,171 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/stack"
+)
+
+// EventType captures high level lifecycle notifications emitted by the
+// orchestrator.
+type EventType string
+
+const (
+	EventTypeStarting EventType = "starting"
+	EventTypeStarted  EventType = "started"
+	EventTypeReady    EventType = "ready"
+	EventTypeStopping EventType = "stopping"
+	EventTypeStopped  EventType = "stopped"
+	EventTypeLog      EventType = "log"
+	EventTypeError    EventType = "error"
+)
+
+// Event represents a single lifecycle or log notification.
+type Event struct {
+	Timestamp time.Time
+	Service   string
+	Type      EventType
+	Message   string
+	Err       error
+}
+
+// Orchestrator coordinates runtime adapters to bring services up respecting the
+// dependency DAG.
+type Orchestrator struct {
+	runtimes runtime.Registry
+}
+
+// NewOrchestrator constructs an orchestrator backed by the provided runtime
+// registry.
+func NewOrchestrator(reg runtime.Registry) *Orchestrator {
+	return &Orchestrator{runtimes: reg.Clone()}
+}
+
+// Deployment tracks state for services started by the orchestrator.
+type Deployment struct {
+	handles []*serviceHandle
+	logs    sync.WaitGroup
+
+	stopOnce sync.Once
+	stopErr  error
+}
+
+type serviceHandle struct {
+	name     string
+	instance runtime.Instance
+}
+
+// Up launches services described by the stack in topological order. Events are
+// delivered to the supplied channel. The returned deployment must be stopped by
+// the caller to release resources.
+func (o *Orchestrator) Up(ctx context.Context, doc *stack.StackFile, graph *Graph, events chan<- Event) (*Deployment, error) {
+	if doc == nil {
+		return nil, errors.New("stack document is nil")
+	}
+	if graph == nil {
+		return nil, errors.New("dependency graph is nil")
+	}
+
+	deployment := &Deployment{handles: make([]*serviceHandle, 0, len(graph.Services()))}
+
+	services := graph.Services()
+	for i := len(services) - 1; i >= 0; i-- {
+		name := services[i]
+		svc, ok := doc.Services[name]
+		if !ok {
+			return nil, fmt.Errorf("service %s missing from stack", name)
+		}
+		runtimeImpl, ok := o.runtimes[svc.Runtime]
+		if !ok {
+			return nil, fmt.Errorf("service %s references unsupported runtime %q", name, svc.Runtime)
+		}
+
+		sendEvent(events, name, EventTypeStarting, "starting service", nil)
+		instance, err := runtimeImpl.Start(ctx, name, svc)
+		if err != nil {
+			sendEvent(events, name, EventTypeError, "start failed", err)
+			startErr := fmt.Errorf("start service %s: %w", name, err)
+			if cleanupErr := cleanupDeployment(deployment, events); cleanupErr != nil {
+				startErr = fmt.Errorf("%w (cleanup failed: %v)", startErr, cleanupErr)
+			}
+			return nil, startErr
+		}
+		handle := &serviceHandle{name: name, instance: instance}
+		deployment.handles = append(deployment.handles, handle)
+
+		sendEvent(events, name, EventTypeStarted, "service started", nil)
+		if logCh := instance.Logs(); logCh != nil {
+			deployment.logs.Add(1)
+			go streamLogs(name, logCh, events, &deployment.logs)
+		}
+
+		if err := instance.WaitReady(ctx); err != nil {
+			sendEvent(events, name, EventTypeError, "readiness failed", err)
+			readyErr := fmt.Errorf("service %s failed readiness: %w", name, err)
+			if cleanupErr := cleanupDeployment(deployment, events); cleanupErr != nil {
+				readyErr = fmt.Errorf("%w (cleanup failed: %v)", readyErr, cleanupErr)
+			}
+			return nil, readyErr
+		}
+		sendEvent(events, name, EventTypeReady, "service ready", nil)
+	}
+
+	return deployment, nil
+}
+
+// Stop terminates all services tracked by the deployment in reverse order. The
+// method is idempotent; subsequent calls return the first error that occurred.
+func (d *Deployment) Stop(ctx context.Context, events chan<- Event) error {
+	d.stopOnce.Do(func() {
+		var firstErr error
+		for i := len(d.handles) - 1; i >= 0; i-- {
+			handle := d.handles[i]
+			sendEvent(events, handle.name, EventTypeStopping, "stopping service", nil)
+			if err := handle.instance.Stop(ctx); err != nil {
+				sendEvent(events, handle.name, EventTypeError, "stop failed", err)
+				if firstErr == nil {
+					firstErr = fmt.Errorf("stop service %s: %w", handle.name, err)
+				}
+				continue
+			}
+			sendEvent(events, handle.name, EventTypeStopped, "service stopped", nil)
+		}
+		d.logs.Wait()
+		d.stopErr = firstErr
+	})
+	return d.stopErr
+}
+
+func cleanupDeployment(dep *Deployment, events chan<- Event) error {
+	if dep == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return dep.Stop(ctx, events)
+}
+
+func sendEvent(events chan<- Event, service string, t EventType, message string, err error) {
+	if events == nil {
+		return
+	}
+	events <- Event{
+		Timestamp: time.Now(),
+		Service:   service,
+		Type:      t,
+		Message:   message,
+		Err:       err,
+	}
+}
+
+func streamLogs(service string, logs <-chan string, events chan<- Event, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for line := range logs {
+		sendEvent(events, service, EventTypeLog, line, nil)
+	}
+}

--- a/internal/runtime/docker/docker.go
+++ b/internal/runtime/docker/docker.go
@@ -1,0 +1,22 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/stack"
+)
+
+type runtimeImpl struct{}
+
+// New returns a runtime adapter placeholder for Docker based workloads. The
+// implementation currently surfaces an informative error because integrating
+// with a container runtime is outside the scope of these changes.
+func New() runtime.Runtime {
+	return &runtimeImpl{}
+}
+
+func (r *runtimeImpl) Start(ctx context.Context, name string, svc *stack.Service) (runtime.Instance, error) {
+	return nil, fmt.Errorf("docker runtime for service %s is not implemented", name)
+}

--- a/internal/runtime/process/process.go
+++ b/internal/runtime/process/process.go
@@ -1,0 +1,140 @@
+package process
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/stack"
+)
+
+type runtimeImpl struct{}
+
+// New constructs a runtime that executes services as local processes.
+func New() runtime.Runtime {
+	return &runtimeImpl{}
+}
+
+func (r *runtimeImpl) Start(ctx context.Context, name string, svc *stack.Service) (runtime.Instance, error) {
+	if len(svc.Command) == 0 {
+		return nil, fmt.Errorf("process runtime for service %s requires a command", name)
+	}
+
+	cmd := exec.CommandContext(ctx, svc.Command[0], svc.Command[1:]...)
+	if svc.Env != nil {
+		env := make([]string, 0, len(svc.Env))
+		for k, v := range svc.Env {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+		cmd.Env = append(cmd.Env, env...)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("service %s stdout: %w", name, err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("service %s stderr: %w", name, err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start service %s: %w", name, err)
+	}
+
+	inst := &processInstance{
+		name:    name,
+		cmd:     cmd,
+		logs:    make(chan string, 64),
+		waitErr: make(chan error, 1),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go inst.streamLogs(stdout, &wg)
+	go inst.streamLogs(stderr, &wg)
+	go func() {
+		wg.Wait()
+		close(inst.logs)
+	}()
+
+	go func() {
+		inst.waitErr <- cmd.Wait()
+		close(inst.waitErr)
+	}()
+
+	return inst, nil
+}
+
+type processInstance struct {
+	name    string
+	cmd     *exec.Cmd
+	logs    chan string
+	waitErr chan error
+}
+
+func (p *processInstance) WaitReady(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err, ok := <-p.waitErr:
+		if ok && err != nil {
+			return fmt.Errorf("process %s exited: %w", p.name, err)
+		}
+		if !ok {
+			return errors.New("process wait channel closed unexpectedly")
+		}
+		return nil
+	case <-time.After(100 * time.Millisecond):
+		return nil
+	}
+}
+
+func (p *processInstance) Stop(ctx context.Context) error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+	// Attempt a graceful shutdown first.
+	_ = p.cmd.Process.Signal(syscall.SIGTERM)
+
+	select {
+	case err, ok := <-p.waitErr:
+		if ok {
+			return err
+		}
+		return nil
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	if err := p.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("kill process %s: %w", p.name, err)
+	}
+	if err, ok := <-p.waitErr; ok {
+		return err
+	}
+	return nil
+}
+
+func (p *processInstance) Logs() <-chan string {
+	return p.logs
+}
+
+func (p *processInstance) streamLogs(r io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\n")
+		p.logs <- line
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,45 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/example/orco/internal/stack"
+)
+
+// Instance represents a single running service instance managed by a runtime
+// adapter.
+type Instance interface {
+	// WaitReady blocks until the instance is considered ready or the
+	// provided context is cancelled.
+	WaitReady(ctx context.Context) error
+
+	// Stop terminates the instance. Implementations should be idempotent
+	// and safe to call multiple times.
+	Stop(ctx context.Context) error
+
+	// Logs returns a channel of log lines associated with the instance. The
+	// channel should be closed once the instance has stopped. A nil channel
+	// indicates that the runtime does not provide log streaming.
+	Logs() <-chan string
+}
+
+// Runtime describes a backend capable of launching services.
+type Runtime interface {
+	// Start launches the provided service and returns a handle to the
+	// running instance. Implementations should respect context cancellation
+	// and surface failures via returned errors.
+	Start(ctx context.Context, name string, svc *stack.Service) (Instance, error)
+}
+
+// Registry maps runtime identifiers to their concrete implementations.
+type Registry map[string]Runtime
+
+// Clone returns a shallow copy of the registry, allowing callers to avoid
+// accidental mutation of shared maps.
+func (r Registry) Clone() Registry {
+	dup := make(Registry, len(r))
+	for k, v := range r {
+		dup[k] = v
+	}
+	return dup
+}


### PR DESCRIPTION
## Summary
- add runtime interfaces and adapters for process and docker runtimes
- implement an engine orchestrator that launches services in dependency order and emits lifecycle events
- update the `orco up` command to drive the orchestrator, stream events, and add integration tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df17e68b90832587e07ff8a9000beb