### PR TITLE
Add health probe runner and update process readiness

### DIFF
--- a/internal/probe/runner.go
+++ b/internal/probe/runner.go
@@ -1,0 +1,183 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"slices"
+	"time"
+
+	"github.com/example/orco/internal/stack"
+)
+
+// Runner executes readiness probes defined by a stack.Health specification.
+type Runner struct {
+	health     *stack.Health
+	httpClient *http.Client
+	dialer     func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// NewRunner constructs a runner for the provided health specification.
+func NewRunner(health *stack.Health) *Runner {
+	client := &http.Client{}
+	dialer := (&net.Dialer{}).DialContext
+	return &Runner{
+		health:     health,
+		httpClient: client,
+		dialer:     dialer,
+	}
+}
+
+// Run blocks until the probe succeeds according to the configured thresholds or
+// returns an error once the failure threshold is exceeded.
+func (r *Runner) Run(ctx context.Context) error {
+	if r == nil || r.health == nil {
+		return nil
+	}
+
+	h := r.health
+	successNeeded := h.SuccessThreshold
+	if successNeeded <= 0 {
+		successNeeded = 1
+	}
+	failureAllowed := h.FailureThreshold
+	if failureAllowed <= 0 {
+		failureAllowed = 1
+	}
+	interval := h.Interval.Duration
+
+	if gp := h.GracePeriod.Duration; gp > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(gp):
+		}
+	}
+
+	successes := 0
+	failures := 0
+	var lastErr error
+
+	for {
+		attemptCtx := ctx
+		cancel := func() {}
+		if pt := r.probeTimeout(); pt > 0 {
+			attemptCtx, cancel = context.WithTimeout(ctx, pt)
+		}
+
+		err := r.execute(attemptCtx)
+		cancel()
+
+		if err == nil {
+			successes++
+			failures = 0
+			if successes >= successNeeded {
+				return nil
+			}
+		} else {
+			if ctx.Err() != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return ctx.Err()
+				}
+			}
+			successes = 0
+			failures++
+			lastErr = err
+			if failures >= failureAllowed {
+				return fmt.Errorf("probe failed after %d consecutive errors: %w", failures, lastErr)
+			}
+		}
+
+		if interval <= 0 {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+func (r *Runner) execute(ctx context.Context) error {
+	switch {
+	case r.health.HTTP != nil:
+		return r.runHTTP(ctx, r.health.HTTP)
+	case r.health.TCP != nil:
+		return r.runTCP(ctx, r.health.TCP)
+	case r.health.Command != nil:
+		return r.runCommand(ctx, r.health.Command)
+	default:
+		return errors.New("no probe configured")
+	}
+}
+
+func (r *Runner) probeTimeout() time.Duration {
+	if r.health == nil {
+		return 0
+	}
+	if r.health.Command != nil && r.health.Command.Timeout.Duration > 0 {
+		return r.health.Command.Timeout.Duration
+	}
+	return r.health.Timeout.Duration
+}
+
+func (r *Runner) runHTTP(ctx context.Context, probe *stack.HTTPProbe) error {
+	if probe == nil {
+		return errors.New("http probe missing configuration")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probe.URL, nil)
+	if err != nil {
+		return fmt.Errorf("http probe request: %w", err)
+	}
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("http probe request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if len(probe.ExpectStatus) > 0 {
+		if !slices.Contains(probe.ExpectStatus, resp.StatusCode) {
+			return fmt.Errorf("http probe unexpected status %d", resp.StatusCode)
+		}
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return fmt.Errorf("http probe unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (r *Runner) runTCP(ctx context.Context, probe *stack.TCPProbe) error {
+	if probe == nil {
+		return errors.New("tcp probe missing configuration")
+	}
+	conn, err := r.dialer(ctx, "tcp", probe.Address)
+	if err != nil {
+		return fmt.Errorf("tcp probe dial %s: %w", probe.Address, err)
+	}
+	conn.Close()
+	return nil
+}
+
+func (r *Runner) runCommand(ctx context.Context, probe *stack.CommandProbe) error {
+	if probe == nil {
+		return errors.New("command probe missing configuration")
+	}
+	if len(probe.Command) == 0 {
+		return errors.New("command probe requires a command")
+	}
+	cmd := exec.CommandContext(ctx, probe.Command[0], probe.Command[1:]...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("command probe failed: %w", err)
+	}
+	return nil
+}

--- a/internal/probe/runner_test.go
+++ b/internal/probe/runner_test.go
@@ -1,0 +1,212 @@
+package probe
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/example/orco/internal/stack"
+)
+
+func TestRunnerHTTPProbeSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: 10 * time.Millisecond},
+		Timeout:          stack.Duration{Duration: 100 * time.Millisecond},
+		FailureThreshold: 3,
+		SuccessThreshold: 1,
+		HTTP: &stack.HTTPProbe{
+			URL:          server.URL,
+			ExpectStatus: []int{http.StatusOK},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := NewRunner(health).Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRunnerHTTPProbeFailureThreshold(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: 10 * time.Millisecond},
+		Timeout:          stack.Duration{Duration: 50 * time.Millisecond},
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		HTTP: &stack.HTTPProbe{
+			URL: server.URL,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := NewRunner(health).Run(ctx); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestRunnerHTTPProbeSuccessThreshold(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := atomic.AddInt32(&hits, 1)
+		if attempt < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: 10 * time.Millisecond},
+		Timeout:          stack.Duration{Duration: 50 * time.Millisecond},
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+		HTTP: &stack.HTTPProbe{
+			URL: server.URL,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := NewRunner(health).Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRunnerTCPProbe(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: 10 * time.Millisecond},
+		Timeout:          stack.Duration{Duration: 50 * time.Millisecond},
+		FailureThreshold: 3,
+		SuccessThreshold: 1,
+		TCP: &stack.TCPProbe{
+			Address: ln.Addr().String(),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := NewRunner(health).Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRunnerCommandProbe(t *testing.T) {
+	shell := "/bin/sh"
+	if runtime.GOOS == "windows" {
+		t.Skip("shell not available on windows test environment")
+	}
+
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: 10 * time.Millisecond},
+		Timeout:          stack.Duration{Duration: 100 * time.Millisecond},
+		FailureThreshold: 3,
+		SuccessThreshold: 1,
+		Command: &stack.CommandProbe{
+			Command: []string{shell, "-c", "exit 0"},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := NewRunner(health).Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRunnerCommandProbeFailureThreshold(t *testing.T) {
+	shell := "/bin/sh"
+	if runtime.GOOS == "windows" {
+		t.Skip("shell not available on windows test environment")
+	}
+
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: 10 * time.Millisecond},
+		Timeout:          stack.Duration{Duration: 100 * time.Millisecond},
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		Command: &stack.CommandProbe{
+			Command: []string{shell, "-c", "exit 1"},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := NewRunner(health).Run(ctx); err == nil {
+		t.Fatalf("expected failure, got nil")
+	}
+}
+
+func TestRunnerCommandProbeTimeoutOverride(t *testing.T) {
+	shell := "/bin/sh"
+	if runtime.GOOS == "windows" {
+		t.Skip("shell not available on windows test environment")
+	}
+
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: 10 * time.Millisecond},
+		Timeout:          stack.Duration{Duration: time.Second},
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		Command: &stack.CommandProbe{
+			Command: []string{shell, "-c", "sleep 0.2"},
+			Timeout: stack.Duration{Duration: 50 * time.Millisecond},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := NewRunner(health).Run(ctx); err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if time.Since(start) > 500*time.Millisecond {
+		t.Fatalf("probe did not respect command timeout override")
+	}
+}

--- a/internal/runtime/process/process_test.go
+++ b/internal/runtime/process/process_test.go
@@ -1,0 +1,100 @@
+package process
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	stdruntime "runtime"
+	"testing"
+	"time"
+
+	"github.com/example/orco/internal/engine"
+	runtimelib "github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/stack"
+)
+
+func TestWaitReadyBlocksUntilProbeSuccess(t *testing.T) {
+	if stdruntime.GOOS == "windows" {
+		t.Skip("process runtime tests skipped on windows")
+	}
+
+	tempDir := t.TempDir()
+	readyFile := filepath.Join(tempDir, "db-ready")
+	startedFile := filepath.Join(tempDir, "web-started")
+
+	dbService := &stack.Service{
+		Runtime: "process",
+		Command: []string{"/bin/sh", "-c", "sleep 0.3; touch " + readyFile + "; sleep 1"},
+		Health: &stack.Health{
+			GracePeriod:      stack.Duration{},
+			Interval:         stack.Duration{Duration: 20 * time.Millisecond},
+			Timeout:          stack.Duration{Duration: 100 * time.Millisecond},
+			FailureThreshold: 50,
+			SuccessThreshold: 1,
+			Command: &stack.CommandProbe{
+				Command: []string{"/bin/sh", "-c", "test -f " + readyFile},
+			},
+		},
+	}
+
+	webService := &stack.Service{
+		Runtime: "process",
+		DependsOn: []stack.Dependency{{
+			Target: "db",
+		}},
+		Command: []string{"/bin/sh", "-c", "touch " + startedFile + "; sleep 0.1"},
+	}
+
+	doc := &stack.StackFile{
+		Services: map[string]*stack.Service{
+			"db":  dbService,
+			"web": webService,
+		},
+	}
+
+	graph, err := engine.BuildGraph(doc)
+	if err != nil {
+		t.Fatalf("build graph: %v", err)
+	}
+
+	orch := engine.NewOrchestrator(runtimelib.Registry{"process": New()})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	deployment, err := orch.Up(ctx, doc, graph, nil)
+	if err != nil {
+		t.Fatalf("orchestrator up: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		if err := deployment.Stop(stopCtx, nil); err != nil {
+			t.Logf("deployment stop returned error: %v", err)
+		}
+	})
+
+	waitForFile := func(path string) os.FileInfo {
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			info, err := os.Stat(path)
+			if err == nil {
+				return info
+			}
+			if !os.IsNotExist(err) {
+				t.Fatalf("stat %s: %v", path, err)
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for %s", path)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	dbInfo := waitForFile(readyFile)
+	webInfo := waitForFile(startedFile)
+
+	if webInfo.ModTime().Before(dbInfo.ModTime()) {
+		t.Fatalf("web started before dependency was ready: web=%v db=%v", webInfo.ModTime(), dbInfo.ModTime())
+	}
+}


### PR DESCRIPTION
## Summary
- add a reusable probe runner that evaluates HTTP, TCP, and command health checks with thresholds and timing controls
- persist service health configuration in process instances and drive WaitReady from the probe runner
- add unit tests for each probe type plus integration coverage showing dependency startup waits for probe success

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df203413908325a9a6a94976044783