### PR TITLE
Merge default health configuration into services

### DIFF
--- a/internal/stack/parser.go
+++ b/internal/stack/parser.go
@@ -41,8 +41,12 @@ func (s *StackFile) ApplyDefaults() error {
 		if svc.RestartPolicy == nil && s.Defaults.RestartPolicy != nil {
 			svc.RestartPolicy = s.Defaults.RestartPolicy.Clone()
 		}
-		if svc.Health == nil && s.Defaults.Health != nil {
-			svc.Health = s.Defaults.Health.Clone()
+		if s.Defaults.Health != nil {
+			if svc.Health == nil {
+				svc.Health = s.Defaults.Health.Clone()
+			} else {
+				svc.Health.ApplyDefaults(s.Defaults.Health)
+			}
 		}
 	}
 	return nil

--- a/internal/stack/parser_test.go
+++ b/internal/stack/parser_test.go
@@ -1,6 +1,10 @@
 package stack
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestStackFileValidateAcceptsSupportedRuntimes(t *testing.T) {
 	tests := map[string]string{
@@ -43,5 +47,60 @@ func TestStackFileValidateRejectsUnsupportedRuntime(t *testing.T) {
 	err := sf.Validate()
 	if err == nil {
 		t.Fatalf("expected error for unsupported runtime")
+	}
+}
+
+func TestApplyDefaultsMergesHealth(t *testing.T) {
+	input := `version: 0.1
+stack:
+  name: test
+defaults:
+  health:
+    interval: 10s
+    timeout: 3s
+    gracePeriod: 1m
+    failureThreshold: 9
+    successThreshold: 4
+services:
+  api:
+    runtime: docker
+    replicas: 1
+    health:
+      http:
+        url: http://localhost:8080/health
+`
+
+	stack, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parse stack: %v", err)
+	}
+
+	svc, ok := stack.Services["api"]
+	if !ok {
+		t.Fatalf("expected api service to be present")
+	}
+
+	if svc.Health == nil {
+		t.Fatalf("expected health configuration to be set")
+	}
+
+	if svc.Health.HTTP == nil {
+		t.Fatalf("expected http probe to remain configured")
+	}
+
+	if got := svc.Health.Interval.Duration; got != 10*time.Second {
+		t.Fatalf("expected interval default of 10s, got %s", got)
+	}
+	if got := svc.Health.Timeout.Duration; got != 3*time.Second {
+		t.Fatalf("expected timeout default of 3s, got %s", got)
+	}
+	if got := svc.Health.GracePeriod.Duration; got != time.Minute {
+		t.Fatalf("expected grace period default of 1m, got %s", got)
+	}
+	if got := svc.Health.FailureThreshold; got != 9 {
+		t.Fatalf("expected failure threshold default of 9, got %d", got)
+	}
+	if got := svc.Health.SuccessThreshold; got != 4 {
+		t.Fatalf("expected success threshold default of 4, got %d", got)
 	}
 }

--- a/internal/stack/types.go
+++ b/internal/stack/types.go
@@ -187,6 +187,28 @@ func (h *Health) Clone() *Health {
 	return &cp
 }
 
+// ApplyDefaults merges non-zero default thresholds and durations into h.
+func (h *Health) ApplyDefaults(def *Health) {
+	if h == nil || def == nil {
+		return
+	}
+	if h.GracePeriod.Duration == 0 && def.GracePeriod.Duration != 0 {
+		h.GracePeriod = def.GracePeriod
+	}
+	if h.Interval.Duration == 0 && def.Interval.Duration != 0 {
+		h.Interval = def.Interval
+	}
+	if h.Timeout.Duration == 0 && def.Timeout.Duration != 0 {
+		h.Timeout = def.Timeout
+	}
+	if h.FailureThreshold == 0 && def.FailureThreshold != 0 {
+		h.FailureThreshold = def.FailureThreshold
+	}
+	if h.SuccessThreshold == 0 && def.SuccessThreshold != 0 {
+		h.SuccessThreshold = def.SuccessThreshold
+	}
+}
+
 // Clone creates a deep copy of the restart policy.
 func (r *RestartPolicy) Clone() *RestartPolicy {
 	if r == nil {


### PR DESCRIPTION
## Summary
- merge stack-level health defaults into each service without overwriting existing probes
- add Health helper to populate missing thresholds and durations while preserving cloning semantics
- extend parser tests to ensure defaults.health values populate service health configuration

## Testing
- `go test ./internal/...` *(fails: hangs downloading external modules in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df23878bf083258cd40141e2281117