### PR TITLE
Add continuous health watcher and readiness transitions

### DIFF
--- a/internal/cli/up_integration_test.go
+++ b/internal/cli/up_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/example/orco/internal/engine"
+	"github.com/example/orco/internal/probe"
 	"github.com/example/orco/internal/runtime"
 	"github.com/example/orco/internal/stack"
 )
@@ -270,6 +271,10 @@ func (i *mockInstance) WaitReady(ctx stdcontext.Context) error {
 		i.runtime.recordReady(i.name)
 		return nil
 	}
+}
+
+func (i *mockInstance) Health() <-chan probe.State {
+	return nil
 }
 
 func (i *mockInstance) Stop(ctx stdcontext.Context) error {

--- a/internal/probe/runner_test.go
+++ b/internal/probe/runner_test.go
@@ -2,9 +2,12 @@ package probe
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -208,5 +211,207 @@ func TestRunnerCommandProbeTimeoutOverride(t *testing.T) {
 	}
 	if time.Since(start) > 500*time.Millisecond {
 		t.Fatalf("probe did not respect command timeout override")
+	}
+}
+
+func TestRunnerWatchHTTPTransitions(t *testing.T) {
+	var phase atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if phase.Load() == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	interval := 20 * time.Millisecond
+	grace := 40 * time.Millisecond
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{Duration: grace},
+		Interval:         stack.Duration{Duration: interval},
+		Timeout:          stack.Duration{Duration: 200 * time.Millisecond},
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		HTTP: &stack.HTTPProbe{
+			URL:          server.URL,
+			ExpectStatus: []int{http.StatusOK},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	states := make(chan State, 8)
+	start := time.Now()
+	go NewRunner(health).Watch(ctx, states)
+
+	ensureNoEvent(t, states, grace/2)
+
+	ready := expectState(t, states, StatusReady, 750*time.Millisecond)
+	if ready.Err != nil {
+		t.Fatalf("unexpected ready error: %v", ready.Err)
+	}
+	if since := time.Since(start); since < grace+interval {
+		t.Fatalf("ready reported too early: %v", since)
+	}
+
+	phase.Store(1)
+	ensureNoEvent(t, states, interval+interval/2)
+
+	unready := expectState(t, states, StatusUnready, 750*time.Millisecond)
+	if unready.Err == nil {
+		t.Fatalf("expected unready event to surface an error")
+	}
+
+	phase.Store(0)
+	ensureNoEvent(t, states, interval+interval/2)
+
+	readyAgain := expectState(t, states, StatusReady, 750*time.Millisecond)
+	if readyAgain.Err != nil {
+		t.Fatalf("unexpected ready error on recovery: %v", readyAgain.Err)
+	}
+}
+
+func TestRunnerWatchCommandTransitions(t *testing.T) {
+	shell := "/bin/sh"
+	if runtime.GOOS == "windows" {
+		t.Skip("shell not available on windows test environment")
+	}
+
+	tempDir := t.TempDir()
+	probeFile := filepath.Join(tempDir, "probe")
+	if err := os.WriteFile(probeFile, []byte{}, 0o644); err != nil {
+		t.Fatalf("create probe file: %v", err)
+	}
+
+	interval := 15 * time.Millisecond
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: interval},
+		Timeout:          stack.Duration{Duration: 200 * time.Millisecond},
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		Command: &stack.CommandProbe{
+			Command: []string{shell, "-c", "test -f " + probeFile},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	states := make(chan State, 8)
+	go NewRunner(health).Watch(ctx, states)
+
+	ready := expectState(t, states, StatusReady, 500*time.Millisecond)
+	if ready.Err != nil {
+		t.Fatalf("unexpected ready error: %v", ready.Err)
+	}
+
+	if err := os.Remove(probeFile); err != nil {
+		t.Fatalf("remove probe file: %v", err)
+	}
+
+	ensureNoEvent(t, states, interval+interval/2)
+
+	unready := expectState(t, states, StatusUnready, 500*time.Millisecond)
+	if unready.Err == nil {
+		t.Fatalf("expected unready event to contain an error")
+	}
+
+	if err := os.WriteFile(probeFile, []byte{}, 0o644); err != nil {
+		t.Fatalf("recreate probe file: %v", err)
+	}
+
+	readyAgain := expectState(t, states, StatusReady, 500*time.Millisecond)
+	if readyAgain.Err != nil {
+		t.Fatalf("unexpected ready error on recovery: %v", readyAgain.Err)
+	}
+}
+
+func TestRunnerWatchTCPTransitions(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	interval := 15 * time.Millisecond
+	health := &stack.Health{
+		GracePeriod:      stack.Duration{},
+		Interval:         stack.Duration{Duration: interval},
+		Timeout:          stack.Duration{Duration: 200 * time.Millisecond},
+		FailureThreshold: 3,
+		SuccessThreshold: 1,
+		TCP: &stack.TCPProbe{
+			Address: ln.Addr().String(),
+		},
+	}
+
+	runner := NewRunner(health)
+	var failing atomic.Bool
+	runner.dialer = func(dialCtx context.Context, network, address string) (net.Conn, error) {
+		if failing.Load() {
+			return nil, errors.New("dial failure")
+		}
+		return (&net.Dialer{}).DialContext(dialCtx, network, address)
+	}
+
+	states := make(chan State, 8)
+	go runner.Watch(ctx, states)
+
+	ready := expectState(t, states, StatusReady, 500*time.Millisecond)
+	if ready.Err != nil {
+		t.Fatalf("unexpected ready error: %v", ready.Err)
+	}
+
+	failing.Store(true)
+	ensureNoEvent(t, states, 2*interval)
+
+	unready := expectState(t, states, StatusUnready, 750*time.Millisecond)
+	if unready.Err == nil {
+		t.Fatalf("expected unready event to include error")
+	}
+
+	failing.Store(false)
+	readyAgain := expectState(t, states, StatusReady, 750*time.Millisecond)
+	if readyAgain.Err != nil {
+		t.Fatalf("unexpected ready error on recovery: %v", readyAgain.Err)
+	}
+}
+
+func expectState(t *testing.T, states <-chan State, status Status, timeout time.Duration) State {
+	t.Helper()
+	select {
+	case state := <-states:
+		if state.Status != status {
+			t.Fatalf("expected state %s, got %s", status, state.Status)
+		}
+		return state
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for state %s", status)
+		return State{}
+	}
+}
+
+func ensureNoEvent(t *testing.T, states <-chan State, duration time.Duration) {
+	t.Helper()
+	select {
+	case state := <-states:
+		t.Fatalf("unexpected state %s during quiet period", state.Status)
+	case <-time.After(duration):
 	}
 }

--- a/internal/runtime/process/process_test.go
+++ b/internal/runtime/process/process_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	stdruntime "runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,10 +27,10 @@ func TestWaitReadyBlocksUntilProbeSuccess(t *testing.T) {
 		Runtime: "process",
 		Command: []string{"/bin/sh", "-c", "sleep 0.3; touch " + readyFile + "; sleep 1"},
 		Health: &stack.Health{
-			GracePeriod:      stack.Duration{},
+			GracePeriod:      stack.Duration{Duration: 350 * time.Millisecond},
 			Interval:         stack.Duration{Duration: 20 * time.Millisecond},
 			Timeout:          stack.Duration{Duration: 100 * time.Millisecond},
-			FailureThreshold: 50,
+			FailureThreshold: 2,
 			SuccessThreshold: 1,
 			Command: &stack.CommandProbe{
 				Command: []string{"/bin/sh", "-c", "test -f " + readyFile},
@@ -59,19 +60,38 @@ func TestWaitReadyBlocksUntilProbeSuccess(t *testing.T) {
 
 	orch := engine.NewOrchestrator(runtimelib.Registry{"process": New()})
 
+	events := make(chan engine.Event, 64)
+	var (
+		mu       sync.Mutex
+		recorded []engine.Event
+	)
+	collectorDone := make(chan struct{})
+	go func() {
+		defer close(collectorDone)
+		for evt := range events {
+			mu.Lock()
+			recorded = append(recorded, evt)
+			mu.Unlock()
+		}
+	}()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	deployment, err := orch.Up(ctx, doc, graph, nil)
+	deployment, err := orch.Up(ctx, doc, graph, events)
 	if err != nil {
+		close(events)
+		<-collectorDone
 		t.Fatalf("orchestrator up: %v", err)
 	}
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer stopCancel()
-		if err := deployment.Stop(stopCtx, nil); err != nil {
+		if err := deployment.Stop(stopCtx, events); err != nil {
 			t.Logf("deployment stop returned error: %v", err)
 		}
+		close(events)
+		<-collectorDone
 	})
 
 	waitForFile := func(path string) os.FileInfo {
@@ -91,10 +111,69 @@ func TestWaitReadyBlocksUntilProbeSuccess(t *testing.T) {
 		}
 	}
 
+	nextEventIdx := 0
+	waitForEvent := func(predicate func(engine.Event) bool, timeout time.Duration) engine.Event {
+		deadline := time.After(timeout)
+		for {
+			mu.Lock()
+			if nextEventIdx < len(recorded) {
+				evt := recorded[nextEventIdx]
+				nextEventIdx++
+				mu.Unlock()
+				if predicate(evt) {
+					return evt
+				}
+				continue
+			}
+			mu.Unlock()
+			select {
+			case <-deadline:
+				t.Fatalf("timed out waiting for event")
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+	}
+
+	dbReady := waitForEvent(func(evt engine.Event) bool {
+		return evt.Service == "db" && evt.Type == engine.EventTypeReady
+	}, 2*time.Second)
+	if dbReady.Err != nil {
+		t.Fatalf("db ready event returned error: %v", dbReady.Err)
+	}
+
+	webReady := waitForEvent(func(evt engine.Event) bool {
+		return evt.Service == "web" && evt.Type == engine.EventTypeReady
+	}, 2*time.Second)
+	if webReady.Err != nil {
+		t.Fatalf("web ready event returned error: %v", webReady.Err)
+	}
+
 	dbInfo := waitForFile(readyFile)
 	webInfo := waitForFile(startedFile)
 
 	if webInfo.ModTime().Before(dbInfo.ModTime()) {
 		t.Fatalf("web started before dependency was ready: web=%v db=%v", webInfo.ModTime(), dbInfo.ModTime())
+	}
+
+	if err := os.Remove(readyFile); err != nil {
+		t.Fatalf("remove ready file: %v", err)
+	}
+
+	dbUnready := waitForEvent(func(evt engine.Event) bool {
+		return evt.Service == "db" && evt.Type == engine.EventTypeUnready
+	}, 2*time.Second)
+	if dbUnready.Err == nil {
+		t.Fatalf("expected unready event to include probe error")
+	}
+
+	if err := os.WriteFile(readyFile, []byte{}, 0o644); err != nil {
+		t.Fatalf("recreate ready file: %v", err)
+	}
+
+	dbReadyAgain := waitForEvent(func(evt engine.Event) bool {
+		return evt.Service == "db" && evt.Type == engine.EventTypeReady
+	}, 2*time.Second)
+	if dbReadyAgain.Err != nil {
+		t.Fatalf("db re-ready event returned error: %v", dbReadyAgain.Err)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 
+	"github.com/example/orco/internal/probe"
 	"github.com/example/orco/internal/stack"
 )
 
@@ -12,6 +13,11 @@ type Instance interface {
 	// WaitReady blocks until the instance is considered ready or the
 	// provided context is cancelled.
 	WaitReady(ctx context.Context) error
+
+	// Health returns a channel that delivers readiness transitions for the
+	// instance. A nil channel indicates that the runtime does not surface
+	// health information beyond the initial readiness gate.
+	Health() <-chan probe.State
 
 	// Stop terminates the instance. Implementations should be idempotent
 	// and safe to call multiple times.


### PR DESCRIPTION
## Summary
- add a long-lived Watch loop to probe runners that emits ready/unready state transitions
- launch probe watchers from the process runtime, surface readiness via a new health channel, and gate dependent services on watcher readiness
- stream health state from the orchestrator, emitting unready events and updating integration tests for the new behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df2721dc34832581be68a9d9ea9993