### PR TITLE
Introduce service supervisor with restart handling

### DIFF
--- a/internal/engine/supervisor.go
+++ b/internal/engine/supervisor.go
@@ -1,0 +1,468 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/example/orco/internal/probe"
+	"github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/stack"
+)
+
+const (
+	defaultBackoffMin    = time.Second
+	defaultBackoffMax    = 30 * time.Second
+	defaultBackoffFactor = 2.0
+	instanceStopTimeout  = 5 * time.Second
+)
+
+type restartPolicy struct {
+	maxRetries int
+	min        time.Duration
+	max        time.Duration
+	factor     float64
+}
+
+// supervisor is responsible for managing the lifecycle of a single service
+// instance. It runs the instance in a dedicated goroutine, observes readiness
+// transitions and initiates restarts based on the configured restart policy.
+type supervisor struct {
+	name    string
+	service *stack.Service
+	runtime runtime.Runtime
+
+	events chan<- Event
+
+	policy restartPolicy
+
+	jitter func(time.Duration) time.Duration
+	sleep  func(context.Context, time.Duration) error
+
+	readyOnce sync.Once
+	readyCh   chan error
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	done chan struct{}
+
+	mu      sync.Mutex
+	current runtime.Instance
+	stopCtx context.Context
+	stopErr error
+	runErr  error
+
+	stopOnce sync.Once
+}
+
+func newSupervisor(name string, svc *stack.Service, rt runtime.Runtime, events chan<- Event) *supervisor {
+	sup := &supervisor{
+		name:    name,
+		service: svc,
+		runtime: rt,
+		events:  events,
+		readyCh: make(chan error, 1),
+		done:    make(chan struct{}),
+	}
+
+	sup.policy = deriveRestartPolicy(svc)
+	sup.jitter = defaultJitter
+	sup.sleep = sleepWithContext
+
+	return sup
+}
+
+func deriveRestartPolicy(svc *stack.Service) restartPolicy {
+	pol := restartPolicy{maxRetries: 3, min: defaultBackoffMin, max: defaultBackoffMax, factor: defaultBackoffFactor}
+	if svc == nil || svc.RestartPolicy == nil {
+		return pol
+	}
+
+	rp := svc.RestartPolicy
+	switch {
+	case rp.MaxRetries < 0:
+		pol.maxRetries = -1
+	case rp.MaxRetries == 0:
+		pol.maxRetries = 0
+	default:
+		pol.maxRetries = rp.MaxRetries
+	}
+	if rp.Backoff != nil {
+		if rp.Backoff.Min.Duration > 0 {
+			pol.min = rp.Backoff.Min.Duration
+		}
+		if rp.Backoff.Max.Duration > 0 {
+			pol.max = rp.Backoff.Max.Duration
+		}
+		if rp.Backoff.Factor > 0 {
+			pol.factor = rp.Backoff.Factor
+		}
+	}
+
+	if pol.min <= 0 {
+		pol.min = defaultBackoffMin
+	}
+	if pol.max <= 0 {
+		pol.max = defaultBackoffMax
+	}
+	if pol.max < pol.min {
+		pol.max = pol.min
+	}
+	if pol.factor <= 1 {
+		pol.factor = defaultBackoffFactor
+	}
+
+	return pol
+}
+
+func defaultJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	// Full jitter: random duration in [0, d].
+	return time.Duration(rand.Float64() * float64(d))
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (s *supervisor) Start(ctx context.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.ctx, s.cancel = context.WithCancel(ctx)
+	go s.run()
+}
+
+func (s *supervisor) run() {
+	defer close(s.done)
+
+	restarts := 0
+	backoffBase := s.policy.min
+
+	for {
+		if err := s.ctx.Err(); err != nil {
+			s.deliverInitial(err)
+			s.setRunErr(err)
+			return
+		}
+
+		sendEvent(s.events, s.name, EventTypeStarting, "starting service", nil)
+
+		instance, err := s.runtime.Start(s.ctx, s.name, s.service)
+		if err != nil {
+			if s.ctx.Err() != nil {
+				s.deliverInitial(s.ctx.Err())
+				s.setRunErr(s.ctx.Err())
+				return
+			}
+
+			sendEvent(s.events, s.name, EventTypeCrashed, "start failed", err)
+			if !s.allowRestart(restarts) {
+				s.deliverInitial(err)
+				s.setRunErr(err)
+				return
+			}
+
+			restarts++
+			if err := s.sleepBackoff(&backoffBase); err != nil {
+				s.deliverInitial(err)
+				s.setRunErr(err)
+				return
+			}
+			continue
+		}
+
+		s.setCurrent(instance)
+		instErr, ready := s.manageInstance(instance)
+		s.clearCurrent()
+
+		if instErr == nil {
+			s.setRunErr(nil)
+			return
+		}
+
+		if errors.Is(instErr, context.Canceled) && s.ctx.Err() != nil {
+			s.deliverInitial(s.ctx.Err())
+			s.setRunErr(s.ctx.Err())
+			return
+		}
+
+		sendEvent(s.events, s.name, EventTypeCrashed, "instance crashed", instErr)
+		if !s.allowRestart(restarts) {
+			if !ready {
+				s.deliverInitial(instErr)
+			}
+			s.setRunErr(instErr)
+			return
+		}
+
+		restarts++
+		if err := s.sleepBackoff(&backoffBase); err != nil {
+			s.setRunErr(err)
+			return
+		}
+	}
+}
+
+func (s *supervisor) allowRestart(restarts int) bool {
+	if s.policy.maxRetries < 0 {
+		return true
+	}
+	return restarts < s.policy.maxRetries
+}
+
+func (s *supervisor) sleepBackoff(base *time.Duration) error {
+	delay := *base
+	if delay <= 0 {
+		delay = s.policy.min
+	}
+	if delay > s.policy.max {
+		delay = s.policy.max
+	}
+
+	jittered := s.jitter(delay)
+	if jittered > s.policy.max {
+		jittered = s.policy.max
+	}
+	if jittered < 0 {
+		jittered = 0
+	}
+
+	if err := s.sleep(s.ctx, jittered); err != nil {
+		return err
+	}
+
+	next := float64(delay) * s.policy.factor
+	if math.IsInf(next, 0) || next > float64(s.policy.max) {
+		*base = s.policy.max
+		return nil
+	}
+	n := time.Duration(next)
+	if n < s.policy.min {
+		n = s.policy.min
+	}
+	if n > s.policy.max {
+		n = s.policy.max
+	}
+	*base = n
+	return nil
+}
+
+func (s *supervisor) manageInstance(instance runtime.Instance) (error, bool) {
+	var logWG sync.WaitGroup
+	if logs := instance.Logs(); logs != nil {
+		logWG.Add(1)
+		go s.streamLogs(logs, &logWG)
+	}
+
+	readyCh := make(chan error, 1)
+	go func() {
+		readyCh <- instance.WaitReady(s.ctx)
+	}()
+
+	healthCh := instance.Health()
+	readyObserved := false
+
+	for {
+		select {
+		case err := <-readyCh:
+			readyCh = nil
+			if err != nil {
+				if s.ctx.Err() != nil && errors.Is(err, context.Canceled) {
+					logWG.Wait()
+					return s.ctx.Err(), readyObserved
+				}
+				ctx, cancel := failureStopContext()
+				_ = s.stopInstance(instance, ctx)
+				cancel()
+				logWG.Wait()
+				return err, readyObserved
+			}
+			readyObserved = true
+			s.deliverInitial(nil)
+			if healthCh == nil {
+				sendEvent(s.events, s.name, EventTypeReady, "service ready", nil)
+			}
+		case state, ok := <-healthCh:
+			if !ok {
+				healthCh = nil
+				if s.ctx.Err() != nil {
+					continue
+				}
+				if readyObserved {
+					ctx, cancel := failureStopContext()
+					_ = s.stopInstance(instance, ctx)
+					cancel()
+					logWG.Wait()
+					return errors.New("health channel closed"), readyObserved
+				}
+				continue
+			}
+			switch state.Status {
+			case probe.StatusReady:
+				readyObserved = true
+				s.deliverInitial(nil)
+				sendEvent(s.events, s.name, EventTypeReady, "service ready", nil)
+			case probe.StatusUnready:
+				if !readyObserved {
+					ctx, cancel := failureStopContext()
+					_ = s.stopInstance(instance, ctx)
+					cancel()
+					logWG.Wait()
+					if state.Err != nil {
+						return state.Err, readyObserved
+					}
+					return errors.New("service reported unready"), readyObserved
+				}
+				sendEvent(s.events, s.name, EventTypeUnready, "service unready", state.Err)
+				ctx, cancel := failureStopContext()
+				_ = s.stopInstance(instance, ctx)
+				cancel()
+				logWG.Wait()
+				if state.Err != nil {
+					return state.Err, readyObserved
+				}
+				return errors.New("service reported unready"), readyObserved
+			}
+		case <-s.ctx.Done():
+			if !readyObserved {
+				s.deliverInitial(s.ctx.Err())
+			}
+			stopCtx := s.stopContext()
+			err := s.stopInstance(instance, stopCtx)
+			s.setStopErr(err)
+			logWG.Wait()
+			sendEvent(s.events, s.name, EventTypeStopped, "service stopped", nil)
+			return nil, readyObserved
+		}
+	}
+}
+
+func (s *supervisor) streamLogs(logs <-chan string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for line := range logs {
+		sendEvent(s.events, s.name, EventTypeLog, line, nil)
+	}
+}
+
+func (s *supervisor) stopInstance(instance runtime.Instance, ctx context.Context) error {
+	if instance == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return instance.Stop(ctx)
+}
+
+func failureStopContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), instanceStopTimeout)
+}
+
+func (s *supervisor) setCurrent(inst runtime.Instance) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current = inst
+}
+
+func (s *supervisor) clearCurrent() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current = nil
+}
+
+func (s *supervisor) stopContext() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopCtx != nil {
+		return s.stopCtx
+	}
+	return context.Background()
+}
+
+func (s *supervisor) setStopErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stopErr = err
+}
+
+func (s *supervisor) getStopErr() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopErr
+}
+
+func (s *supervisor) setRunErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runErr = err
+}
+
+func (s *supervisor) deliverInitial(err error) {
+	s.readyOnce.Do(func() {
+		s.readyCh <- err
+		close(s.readyCh)
+	})
+}
+
+func (s *supervisor) AwaitReady(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-s.readyCh:
+		return err
+	}
+}
+
+func (s *supervisor) Stop(ctx context.Context) error {
+	var result error
+	s.stopOnce.Do(func() {
+		alreadyDone := false
+		select {
+		case <-s.done:
+			alreadyDone = true
+		default:
+		}
+
+		s.mu.Lock()
+		s.stopCtx = ctx
+		s.mu.Unlock()
+		if s.cancel != nil {
+			s.cancel()
+		}
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		if alreadyDone {
+			result = nil
+			return
+		}
+
+		select {
+		case <-s.done:
+			result = s.getStopErr()
+		case <-ctx.Done():
+			result = ctx.Err()
+		}
+	})
+	return result
+}

--- a/internal/engine/supervisor_test.go
+++ b/internal/engine/supervisor_test.go
@@ -1,0 +1,308 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/example/orco/internal/probe"
+	"github.com/example/orco/internal/runtime"
+	"github.com/example/orco/internal/stack"
+)
+
+func TestSupervisorRestartsOnUnready(t *testing.T) {
+	svc := &stack.Service{
+		RestartPolicy: &stack.RestartPolicy{
+			MaxRetries: 3,
+			Backoff: &stack.Backoff{
+				Min:    stack.Duration{Duration: 10 * time.Millisecond},
+				Max:    stack.Duration{Duration: 100 * time.Millisecond},
+				Factor: 2,
+			},
+		},
+	}
+
+	first := &fakeInstance{
+		waitCh:   make(chan error, 1),
+		healthCh: make(chan probe.State, 4),
+	}
+	second := &fakeInstance{
+		waitCh:   make(chan error, 1),
+		healthCh: make(chan probe.State, 2),
+	}
+
+	rt := &fakeRuntime{
+		instances: []*fakeInstance{first, second},
+		startCh:   make(chan struct{}, 4),
+	}
+
+	events := make(chan Event, 32)
+	sup := newSupervisor("web", svc, rt, events)
+	sup.jitter = func(d time.Duration) time.Duration { return d }
+	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sup.Start(ctx)
+
+	// Wait for initial start to be invoked.
+	waitForStart(t, rt.startCh)
+
+	// Drive the first instance to ready.
+	first.waitCh <- nil
+	first.healthCh <- probe.State{Status: probe.StatusReady}
+
+	if err := sup.AwaitReady(context.Background()); err != nil {
+		t.Fatalf("await ready: %v", err)
+	}
+
+	// Trigger an unready transition that should initiate a restart.
+	failure := errors.New("probe failed")
+	first.healthCh <- probe.State{Status: probe.StatusUnready, Err: failure}
+
+	// Allow the supervisor to acquire the second instance.
+	waitForStart(t, rt.startCh)
+
+	second.waitCh <- nil
+	second.healthCh <- probe.State{Status: probe.StatusReady}
+
+	// Collect events until the second instance reports readiness.
+	var types []EventType
+	deadline := time.After(time.Second)
+	for {
+		if len(types) >= 6 {
+			break
+		}
+		select {
+		case evt := <-events:
+			if evt.Service != "web" {
+				continue
+			}
+			types = append(types, evt.Type)
+			if evt.Type == EventTypeReady {
+				// The restart cycle completed.
+				if len(types) >= 6 {
+					break
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for events; got %v", types)
+		}
+	}
+
+	// Expect at least one unready, crash and a subsequent starting event.
+	if !containsSequence(types, []EventType{EventTypeUnready, EventTypeCrashed, EventTypeStarting, EventTypeReady}) {
+		t.Fatalf("expected restart sequence, got %v", types)
+	}
+
+	if err := sup.Stop(context.Background()); err != nil {
+		t.Fatalf("stop supervisor: %v", err)
+	}
+}
+
+func TestSupervisorBackoffJitter(t *testing.T) {
+	svc := &stack.Service{
+		RestartPolicy: &stack.RestartPolicy{
+			MaxRetries: 3,
+			Backoff: &stack.Backoff{
+				Min:    stack.Duration{Duration: 50 * time.Millisecond},
+				Max:    stack.Duration{Duration: 500 * time.Millisecond},
+				Factor: 2,
+			},
+		},
+	}
+
+	fail := &fakeInstance{waitErr: errors.New("not ready")}
+	fail2 := &fakeInstance{waitErr: errors.New("still failing")}
+	fail3 := &fakeInstance{waitErr: errors.New("boom")}
+	fail4 := &fakeInstance{waitErr: errors.New("boom again")}
+
+	rt := &fakeRuntime{instances: []*fakeInstance{fail, fail2, fail3, fail4}}
+
+	var delays []time.Duration
+	sup := newSupervisor("db", svc, rt, make(chan Event, 32))
+	sup.jitter = func(d time.Duration) time.Duration { return d }
+	sup.sleep = func(ctx context.Context, d time.Duration) error {
+		delays = append(delays, d)
+		return nil
+	}
+
+	sup.Start(context.Background())
+
+	if err := sup.AwaitReady(context.Background()); err == nil {
+		t.Fatalf("expected readiness failure")
+	}
+
+	sup.Stop(context.Background())
+
+	expected := []time.Duration{
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+	}
+
+	if len(delays) != len(expected) {
+		t.Fatalf("expected %d backoff delays, got %d (%v)", len(expected), len(delays), delays)
+	}
+
+	for i, d := range expected {
+		if delays[i] != d {
+			t.Fatalf("delay %d: expected %v, got %v", i, d, delays[i])
+		}
+	}
+}
+
+func TestSupervisorMaxRetriesEmitsCrashed(t *testing.T) {
+	svc := &stack.Service{
+		RestartPolicy: &stack.RestartPolicy{
+			MaxRetries: 1,
+			Backoff: &stack.Backoff{
+				Min:    stack.Duration{Duration: 10 * time.Millisecond},
+				Max:    stack.Duration{Duration: 20 * time.Millisecond},
+				Factor: 2,
+			},
+		},
+	}
+
+	inst1 := &fakeInstance{waitErr: errors.New("startup failure")}
+	inst2 := &fakeInstance{waitErr: errors.New("still broken")}
+
+	events := make(chan Event, 32)
+	rt := &fakeRuntime{instances: []*fakeInstance{inst1, inst2}}
+
+	sup := newSupervisor("api", svc, rt, events)
+	sup.jitter = func(d time.Duration) time.Duration { return d }
+	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
+
+	sup.Start(context.Background())
+
+	if err := sup.AwaitReady(context.Background()); err == nil {
+		t.Fatalf("expected readiness failure")
+	}
+
+	sup.Stop(context.Background())
+
+	found := false
+	for len(events) > 0 {
+		evt := <-events
+		if evt.Service != "api" {
+			continue
+		}
+		if evt.Type == EventTypeCrashed {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected crashed event after exhausting retries")
+	}
+}
+
+func containsSequence(events []EventType, seq []EventType) bool {
+	if len(seq) == 0 {
+		return true
+	}
+	idx := 0
+	for _, t := range events {
+		if t == seq[idx] {
+			idx++
+			if idx == len(seq) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func waitForStart(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for runtime start")
+	}
+}
+
+type fakeRuntime struct {
+	mu        sync.Mutex
+	instances []*fakeInstance
+	startCh   chan struct{}
+}
+
+func (f *fakeRuntime) Start(ctx context.Context, name string, svc *stack.Service) (runtime.Instance, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.instances) == 0 {
+		return nil, errors.New("no instances configured")
+	}
+	inst := f.instances[0]
+	f.instances = f.instances[1:]
+	if f.startCh != nil {
+		f.startCh <- struct{}{}
+	}
+	if inst.startErr != nil {
+		return nil, inst.startErr
+	}
+	return inst, nil
+}
+
+type fakeInstance struct {
+	waitErr error
+	waitCh  chan error
+
+	healthCh chan probe.State
+	logsCh   chan string
+
+	stopErr  error
+	startErr error
+}
+
+func (f *fakeInstance) WaitReady(ctx context.Context) error {
+	if f.waitCh != nil {
+		select {
+		case err := <-f.waitCh:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if f.waitErr != nil {
+		return f.waitErr
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}
+
+func (f *fakeInstance) Health() <-chan probe.State {
+	return f.healthCh
+}
+
+func (f *fakeInstance) Stop(ctx context.Context) error {
+	if f.stopErr != nil {
+		return f.stopErr
+	}
+	if f.healthCh != nil {
+		close(f.healthCh)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		default:
+		}
+	}
+	return nil
+}
+
+func (f *fakeInstance) Logs() <-chan string {
+	return f.logsCh
+}


### PR DESCRIPTION
## Summary
- add a supervisor that manages service instances, applies restart policy backoff, and emits lifecycle events
- update the orchestrator to launch supervisors and adjust CLI expectations for repeated starts/stops
- add supervisor unit tests covering restart loops, jittered backoff, and max retry exhaustion

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dfca813d9c8325a24b003533f090da