### PR TITLE
Implement structured NDJSON log fan-in

### DIFF
--- a/internal/cli/logfmt.go
+++ b/internal/cli/logfmt.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/example/orco/internal/engine"
+	"github.com/example/orco/internal/runtime"
+)
+
+type logRecord struct {
+	Timestamp time.Time `json:"ts"`
+	Service   string    `json:"service"`
+	Replica   int       `json:"replica"`
+	Level     string    `json:"level"`
+	Message   string    `json:"msg"`
+	Source    string    `json:"source"`
+}
+
+func newLogRecord(event engine.Event) logRecord {
+	level := event.Level
+	if level == "" {
+		level = "info"
+	}
+	source := event.Source
+	if source == "" {
+		source = runtime.LogSourceSystem
+	}
+	return logRecord{
+		Timestamp: event.Timestamp,
+		Service:   event.Service,
+		Replica:   event.Replica,
+		Level:     level,
+		Message:   event.Message,
+		Source:    source,
+	}
+}
+
+func encodeLogEvent(enc *json.Encoder, stderr io.Writer, event engine.Event) {
+	if enc == nil {
+		return
+	}
+	record := newLogRecord(event)
+	if record.Timestamp.IsZero() {
+		record.Timestamp = time.Now()
+	}
+	if err := enc.Encode(&record); err != nil {
+		fmt.Fprintf(stderr, "error: encode log: %v\n", err)
+	}
+}

--- a/internal/cli/logs_integration_test.go
+++ b/internal/cli/logs_integration_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"bytes"
+	stdcontext "context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/example/orco/internal/engine"
+	runtimelib "github.com/example/orco/internal/runtime"
+)
+
+func TestLogsCommandStreamsStructuredOutput(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+	rt.logs["api"] = []runtimelib.LogEntry{{Message: "api ready", Source: runtimelib.LogSourceStdout}}
+	rt.logs["worker"] = []runtimelib.LogEntry{{Message: "worker started", Source: runtimelib.LogSourceStdout}}
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+services:
+  api:
+    runtime: process
+    command: ["sleep", "0"]
+  worker:
+    runtime: process
+    command: ["sleep", "0"]
+    dependsOn:
+      - target: api
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtimelib.Registry{"process": rt}),
+	}
+
+	cmd := newLogsCmd(ctx)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"-f"})
+
+	cmdCtx, cancel := stdcontext.WithCancel(stdcontext.Background())
+	cmd.SetContext(cmdCtx)
+        go func() {
+                time.Sleep(150 * time.Millisecond)
+                cancel()
+        }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("logs command failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "\"service\":\"api\"") {
+		t.Fatalf("expected api logs in output, got: %s", output)
+	}
+	if !strings.Contains(output, "\"service\":\"worker\"") {
+		t.Fatalf("expected worker logs in output, got: %s", output)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got: %s", stderr.String())
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	stdcontext "context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -57,10 +58,11 @@ func newUpCmd(ctx *context) *cobra.Command {
 }
 
 func printEvents(stdout, stderr io.Writer, events <-chan engine.Event) {
+	encoder := json.NewEncoder(stdout)
 	for event := range events {
 		switch event.Type {
 		case engine.EventTypeLog:
-			fmt.Fprintf(stdout, "[%s] %s\n", event.Service, event.Message)
+			encodeLogEvent(encoder, stderr, event)
 		case engine.EventTypeError:
 			if event.Err != nil {
 				fmt.Fprintf(stderr, "error: %s %s: %v\n", event.Service, event.Message, event.Err)

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -30,8 +30,11 @@ const (
 type Event struct {
 	Timestamp time.Time
 	Service   string
+	Replica   int
 	Type      EventType
 	Message   string
+	Level     string
+	Source    string
 	Err       error
 }
 
@@ -222,8 +225,11 @@ func sendEvent(events chan<- Event, service string, t EventType, message string,
 	events <- Event{
 		Timestamp: time.Now(),
 		Service:   service,
+		Replica:   0,
 		Type:      t,
 		Message:   message,
+		Level:     "info",
+		Source:    runtime.LogSourceSystem,
 		Err:       err,
 	}
 }

--- a/internal/engine/supervisor_test.go
+++ b/internal/engine/supervisor_test.go
@@ -254,7 +254,7 @@ type fakeInstance struct {
 	waitCh  chan error
 
 	healthCh chan probe.State
-	logsCh   chan string
+	logsCh   chan runtime.LogEntry
 
 	stopErr  error
 	startErr error
@@ -303,6 +303,6 @@ func (f *fakeInstance) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (f *fakeInstance) Logs() <-chan string {
+func (f *fakeInstance) Logs() <-chan runtime.LogEntry {
 	return f.logsCh
 }

--- a/internal/runtime/docker/docker_integration_test.go
+++ b/internal/runtime/docker/docker_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/client"
 
 	"github.com/example/orco/internal/probe"
+	"github.com/example/orco/internal/runtime"
 	"github.com/example/orco/internal/stack"
 )
 
@@ -60,13 +61,13 @@ func TestRuntimeStartStopLogs(t *testing.T) {
 		t.Fatal("logs channel is nil")
 	}
 
-	var line string
+	var line runtime.LogEntry
 	select {
 	case line = <-logs:
 	case <-time.After(30 * time.Second):
 		t.Fatal("expected log line")
 	}
-	if line == "" {
+	if line.Message == "" {
 		t.Fatal("expected non-empty log line")
 	}
 


### PR DESCRIPTION
## Summary
- add runtime log entry metadata and propagate it through supervisor events
- normalize log output into NDJSON with shared encoder and drop reporting
- implement `orco logs` streaming with structured output tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e02ae3e9688325aaa20d76f24a4290