### PR TITLE
Delay up command shutdown until context cancellation

### DIFF
--- a/internal/cli/up_integration_test.go
+++ b/internal/cli/up_integration_test.go
@@ -53,6 +53,15 @@ services:
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 
+	runCtx, cancel := stdcontext.WithCancel(stdcontext.Background())
+	defer cancel()
+	cmd.SetContext(runCtx)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("up command failed: %v\nstderr: %s", err, stderr.String())
 	}


### PR DESCRIPTION
## Summary
- defer deployment shutdown in the up command so it waits for context cancellation and reuses the event stream for stop progress
- close the events channel only after shutdown completes and keep the printer goroutine alive for stop output
- update the up integration test to run the command with a cancellable context and trigger cancellation after startup

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e0308ae5bc8325ba809e2aa722bc6f