### PR TITLE
refactor: extract cli utilities

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/example/orco/internal/cliutil"
 	"github.com/example/orco/internal/engine"
 )
 
@@ -46,7 +47,7 @@ func newLogsCmd(ctx *context) *cobra.Command {
 					if filter != "" && event.Service != filter {
 						continue
 					}
-					encodeLogEvent(encoder, cmd.ErrOrStderr(), event)
+					cliutil.EncodeLogEvent(encoder, cmd.ErrOrStderr(), event)
 				}
 			}()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/example/orco/internal/cliutil"
 	"github.com/example/orco/internal/engine"
 	"github.com/example/orco/internal/runtime"
 	"github.com/example/orco/internal/runtime/docker"
@@ -54,8 +55,8 @@ type context struct {
 	orchestrator *engine.Orchestrator
 }
 
-func (c *context) loadStack() (*stackDocument, error) {
-	return loadStackFromFile(*c.stackFile)
+func (c *context) loadStack() (*cliutil.StackDocument, error) {
+	return cliutil.LoadStackFromFile(*c.stackFile)
 }
 
 func (c *context) getOrchestrator() *engine.Orchestrator {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/example/orco/internal/cliutil"
 	"github.com/example/orco/internal/engine"
 )
 
@@ -71,7 +72,7 @@ func printEvents(stdout, stderr io.Writer, events <-chan engine.Event) {
 	for event := range events {
 		switch event.Type {
 		case engine.EventTypeLog:
-			encodeLogEvent(encoder, stderr, event)
+			cliutil.EncodeLogEvent(encoder, stderr, event)
 		case engine.EventTypeError:
 			if event.Err != nil {
 				fmt.Fprintf(stderr, "error: %s %s: %v\n", event.Service, event.Message, event.Err)

--- a/internal/cliutil/doc.go
+++ b/internal/cliutil/doc.go
@@ -1,0 +1,3 @@
+// Package cliutil contains shared helpers for CLI commands such as stack
+// loading and log formatting.
+package cliutil

--- a/internal/cliutil/logfmt.go
+++ b/internal/cliutil/logfmt.go
@@ -1,4 +1,4 @@
-package cli
+package cliutil
 
 import (
 	"encoding/json"
@@ -10,7 +10,8 @@ import (
 	"github.com/example/orco/internal/runtime"
 )
 
-type logRecord struct {
+// LogRecord represents a structured log event ready for JSON encoding.
+type LogRecord struct {
 	Timestamp time.Time `json:"ts"`
 	Service   string    `json:"service"`
 	Replica   int       `json:"replica"`
@@ -19,7 +20,8 @@ type logRecord struct {
 	Source    string    `json:"source"`
 }
 
-func newLogRecord(event engine.Event) logRecord {
+// NewLogRecord converts an engine event into a structured log record.
+func NewLogRecord(event engine.Event) LogRecord {
 	level := event.Level
 	if level == "" {
 		level = "info"
@@ -28,7 +30,7 @@ func newLogRecord(event engine.Event) logRecord {
 	if source == "" {
 		source = runtime.LogSourceSystem
 	}
-	return logRecord{
+	return LogRecord{
 		Timestamp: event.Timestamp,
 		Service:   event.Service,
 		Replica:   event.Replica,
@@ -38,11 +40,12 @@ func newLogRecord(event engine.Event) logRecord {
 	}
 }
 
-func encodeLogEvent(enc *json.Encoder, stderr io.Writer, event engine.Event) {
+// EncodeLogEvent encodes a log event to JSON, reporting errors to stderr if needed.
+func EncodeLogEvent(enc *json.Encoder, stderr io.Writer, event engine.Event) {
 	if enc == nil {
 		return
 	}
-	record := newLogRecord(event)
+	record := NewLogRecord(event)
 	if record.Timestamp.IsZero() {
 		record.Timestamp = time.Now()
 	}

--- a/internal/cliutil/stack.go
+++ b/internal/cliutil/stack.go
@@ -1,4 +1,4 @@
-package cli
+package cliutil
 
 import (
 	"fmt"
@@ -8,13 +8,15 @@ import (
 	"github.com/example/orco/internal/stack"
 )
 
-type stackDocument struct {
+// StackDocument bundles a parsed stack file with the derived dependency graph.
+type StackDocument struct {
 	File   *stack.StackFile
 	Graph  *engine.Graph
 	Source string
 }
 
-func loadStackFromFile(path string) (*stackDocument, error) {
+// LoadStackFromFile parses a stack definition file and returns its document and graph.
+func LoadStackFromFile(path string) (*StackDocument, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open stack file: %w", err)
@@ -29,5 +31,5 @@ func loadStackFromFile(path string) (*stackDocument, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &stackDocument{File: doc, Graph: graph, Source: path}, nil
+	return &StackDocument{File: doc, Graph: graph, Source: path}, nil
 }


### PR DESCRIPTION
## Summary
- add the internal/cliutil helper package with shared stack loading and log formatting utilities
- update CLI commands to consume cliutil helpers and remove in-package duplicates

## Testing
- go test ./... *(fails: TestUpCommandStartsServicesInDependencyOrder already fails on main)*

------
https://chatgpt.com/codex/tasks/task_e_68e03ccb18548325a3a60407f9762a7e