### PR TITLE
Handle CLI cancellation with graceful shutdown

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -63,11 +63,11 @@ func newLogsCmd(ctx *context) *cobra.Command {
 				<-cmd.Context().Done()
 			}
 
-			stopCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), 10*time.Second)
-			defer cancel()
 			var stopErr error
 			if deployment != nil {
+				stopCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), 10*time.Second)
 				stopErr = deployment.Stop(stopCtx, events)
+				cancel()
 			}
 
 			close(events)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	stdcontext "context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -44,7 +47,13 @@ func NewRootCmd() *cobra.Command {
 
 // Execute runs the CLI entrypoint.
 func Execute() {
-	if err := NewRootCmd().Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(stdcontext.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	root := NewRootCmd()
+	root.SetContext(ctx)
+
+	if err := root.ExecuteContext(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary
- create a signal-aware root command context so interrupts cancel command execution
- teach `up` and `logs` to coordinate context cancellation with deployment shutdown
- add integration coverage that verifies deployments stop before long-running commands exit

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e0524bae148325bb1a8180b8c909cd