### PR TITLE
Ensure process runtime terminates spawned child processes

### DIFF
--- a/internal/runtime/process/stop_unix.go
+++ b/internal/runtime/process/stop_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+)
+
+func (p *processInstance) Stop(ctx context.Context) error {
+	p.cancelWatch()
+	if p.cmd.Process == nil {
+		return nil
+	}
+
+	// Attempt a graceful shutdown first.
+	if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("signal process group %s: %w", p.name, err)
+	}
+
+	select {
+	case err, ok := <-p.waitErr:
+		if ok {
+			return err
+		}
+		return nil
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("kill process group %s: %w", p.name, err)
+	}
+	if err, ok := <-p.waitErr; ok {
+		return err
+	}
+	return nil
+}

--- a/internal/runtime/process/stop_windows.go
+++ b/internal/runtime/process/stop_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+func (p *processInstance) Stop(ctx context.Context) error {
+	p.cancelWatch()
+	if p.cmd.Process == nil {
+		return nil
+	}
+	// Attempt a graceful shutdown first.
+	_ = p.cmd.Process.Signal(os.Interrupt)
+
+	select {
+	case err, ok := <-p.waitErr:
+		if ok {
+			return err
+		}
+		return nil
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	if err := p.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("kill process %s: %w", p.name, err)
+	}
+	if err, ok := <-p.waitErr; ok {
+		return err
+	}
+	return nil
+}

--- a/internal/runtime/process/sysprocattr_unix.go
+++ b/internal/runtime/process/sysprocattr_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package process
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureCmdSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/runtime/process/sysprocattr_windows.go
+++ b/internal/runtime/process/sysprocattr_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package process
+
+import "os/exec"
+
+func configureCmdSysProcAttr(cmd *exec.Cmd) {}


### PR DESCRIPTION
## Summary
- configure process runtime commands to run in their own process group on Unix
- send SIGTERM/SIGKILL to the entire process group when stopping services
- add a regression test that verifies Stop terminates both parent and child processes

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e05d22bab48325a3e4ed08ae587d64