### PR TITLE
Add CLI tui command for interactive stack interface

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newGraphCmd(ctx))
 	root.AddCommand(newRestartCmd(ctx))
 	root.AddCommand(newApplyCmd(ctx))
+	root.AddCommand(newTuiCmd(ctx))
 
 	root.SilenceUsage = true
 	root.SilenceErrors = true

--- a/internal/cli/tui_cmd.go
+++ b/internal/cli/tui_cmd.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newTuiCmd(ctx *context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tui",
+		Short: "Launch the interactive status interface",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !supportsInteractiveOutput(cmd) {
+				return fmt.Errorf("tui requires an interactive terminal")
+			}
+
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+
+			return runStackTUI(cmd, ctx, doc)
+		},
+	}
+
+	return cmd
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -30,13 +30,13 @@ func newUpCmd(ctx *context) *cobra.Command {
 			if !supportsInteractiveOutput(cmd) {
 				return runUpNonInteractive(cmd, ctx, doc)
 			}
-			return runUpInteractive(cmd, ctx, doc)
+			return runStackTUI(cmd, ctx, doc)
 		},
 	}
 	return cmd
 }
 
-func runUpInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (retErr error) {
+func runStackTUI(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (retErr error) {
 	ui := tui.New()
 	uiErrCh := make(chan error, 1)
 	go func() {
@@ -79,6 +79,10 @@ func runUpInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocume
 	}
 
 	return retErr
+}
+
+func runUpInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (retErr error) {
+	return runStackTUI(cmd, ctx, doc)
 }
 
 func runUpNonInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (retErr error) {


### PR DESCRIPTION
## Summary
- add a `tui` Cobra command that launches the interactive orchestrator UI
- share the TUI runner logic between the new command and the interactive `up` flow
- register the command on the root CLI so `orco tui` is available

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e06625ad7c83258ac744b71f86dff5