### PR TITLE
Add config lint command

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/example/orco/internal/config"
+)
+
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Work with stack configuration files",
+	}
+	cmd.AddCommand(newConfigLintCmd())
+	return cmd
+}
+
+func newConfigLintCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lint",
+		Short: "Validate a stack configuration file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "stack.yaml"
+			if flag := cmd.Flag("file"); flag != nil {
+				if value := flag.Value.String(); value != "" {
+					path = value
+				}
+			} else if inherited := cmd.InheritedFlags().Lookup("file"); inherited != nil {
+				if value := inherited.Value.String(); value != "" {
+					path = value
+				}
+			}
+
+			if _, err := config.Load(path); err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), err)
+				return err
+			}
+
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigLintSuccess(t *testing.T) {
+	dir := t.TempDir()
+	manifest := []byte(`version: 0.1
+stack:
+  name: demo
+services:
+  api:
+    image: example/api:latest
+    runtime: docker
+    health:
+      tcp:
+        address: localhost:8080
+`)
+	path := filepath.Join(dir, "stack.yaml")
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	cmd := NewRootCmd()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"config", "lint", "--file", path})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr output: %q", stderr.String())
+	}
+}
+
+func TestConfigLintFailure(t *testing.T) {
+	dir := t.TempDir()
+	manifest := []byte(`version: 0.1
+stack: {}
+services:
+  api:
+    image: example/api:latest
+    runtime: docker
+    health:
+      tcp:
+        address: localhost:8080
+`)
+	path := filepath.Join(dir, "stack.yaml")
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	cmd := NewRootCmd()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"config", "lint", "--file", path})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if got := stderr.String(); got == "" {
+		t.Fatalf("expected stderr output, got empty string")
+	} else if !strings.Contains(got, "stack.yaml") {
+		t.Fatalf("stderr does not mention stack path: %q", got)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newRestartCmd(ctx))
 	root.AddCommand(newApplyCmd(ctx))
 	root.AddCommand(newTuiCmd(ctx))
+	root.AddCommand(newConfigCmd())
 
 	root.SilenceUsage = true
 	root.SilenceErrors = true


### PR DESCRIPTION
## Summary
- add a `config` command with a `lint` subcommand to validate stack manifests
- hook the new command into the root command and cover success and failure cases with tests

## Testing
- go test ./internal/cli -run TestConfigLint -count=1


------
https://chatgpt.com/codex/tasks/task_e_68e06a851f888325a55355469de521a5