### PR TITLE
Clone default health probes when applying service defaults

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -274,6 +274,21 @@ func (p *ProbeSpec) ApplyDefaults(defaults *ProbeSpec) {
 	if defaults == nil {
 		return
 	}
+	if p.HTTP == nil && defaults.HTTP != nil {
+		p.HTTP = &HTTPProbeSpec{
+			URL:          defaults.HTTP.URL,
+			ExpectStatus: append([]int(nil), defaults.HTTP.ExpectStatus...),
+		}
+	}
+	if p.TCP == nil && defaults.TCP != nil {
+		p.TCP = &TCPProbeSpec{Address: defaults.TCP.Address}
+	}
+	if p.Command == nil && defaults.Command != nil {
+		p.Command = &CommandProbe{
+			Command: append([]string(nil), defaults.Command.Command...),
+			Timeout: defaults.Command.Timeout,
+		}
+	}
 	if p.GracePeriod.Duration == 0 {
 		p.GracePeriod = defaults.GracePeriod
 	}


### PR DESCRIPTION
## Summary
- clone missing HTTP, TCP, or command probes from the defaults spec before applying scalar health defaults
- add a regression test to ensure services overriding probe timings inherit default HTTP probe configuration

## Testing
- `go test ./internal/config -run TestLoadServiceOverridesTimingInheritsDefaultProbe -v -json`


------
https://chatgpt.com/codex/tasks/task_e_68e0725a1a248325a3539cee7f76b437