### PR TITLE
Enforce runtime-specific service validation

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -114,6 +114,55 @@ services:
 	}
 }
 
+func TestLoadDockerRuntimeRequiresImage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	manifest := []byte(`version: 0.1
+stack:
+  name: demo
+services:
+  api:
+    runtime: docker
+    health:
+      tcp:
+        address: localhost:1234
+`)
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "services.api.image") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadProcessRuntimeRequiresCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	manifest := []byte(`version: 0.1
+stack:
+  name: demo
+services:
+  worker:
+    runtime: process
+`)
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "services.worker.command") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadServiceOverridesTimingInheritsDefaultProbe(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "stack.yaml")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -167,6 +167,16 @@ func (s *Stack) Validate() error {
 		if svc.Runtime != "docker" && svc.Runtime != "process" {
 			return fmt.Errorf("%s: unsupported runtime %q (supported values: docker, process)", serviceField(name, "runtime"), svc.Runtime)
 		}
+		if svc.Runtime == "docker" {
+			if strings.TrimSpace(svc.Image) == "" {
+				return fmt.Errorf("%s: is required", serviceField(name, "image"))
+			}
+		}
+		if svc.Runtime == "process" {
+			if len(svc.Command) == 0 {
+				return fmt.Errorf("%s: must contain at least one entry", serviceField(name, "command"))
+			}
+		}
 		if svc.Health != nil {
 			if err := validateProbe(name, svc.Health); err != nil {
 				return err


### PR DESCRIPTION
## Summary
- require docker services to define an image and process services to provide a command during stack validation
- add config loader and CLI lint tests covering the new runtime-specific validation failures

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e0767eb86c8325b18693a5ec9fde5a