### PR TITLE
Enforce per-service health probes during stack validation

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -292,6 +292,30 @@ services:
 	}
 }
 
+func TestLoadServiceMissingHealthFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	manifest := []byte(`version: 0.1
+stack:
+  name: demo
+services:
+  api:
+    image: ghcr.io/demo/api:latest
+    runtime: docker
+`)
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "services.api.health") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadMalformedPort(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "stack.yaml")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -177,10 +177,11 @@ func (s *Stack) Validate() error {
 				return fmt.Errorf("%s: must contain at least one entry", serviceField(name, "command"))
 			}
 		}
-		if svc.Health != nil {
-			if err := validateProbe(name, svc.Health); err != nil {
-				return err
-			}
+		if svc.Health == nil {
+			return fmt.Errorf("%s: is required", serviceField(name, "health"))
+		}
+		if err := validateProbe(name, svc.Health); err != nil {
+			return err
 		}
 		if svc.Replicas < 1 {
 			return fmt.Errorf("%s: must be at least 1", serviceField(name, "replicas"))


### PR DESCRIPTION
## Summary
- ensure stack validation requires each service to define a health probe and emits a path-qualified error when missing
- cover the regression with a loader test that asserts stacks lacking probes fail validation

## Testing
- `go test -json ./internal/config -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68e07b65b8e08325b52c75b1f6d1556c