### PR TITLE
Enhance port mapping validation

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -344,6 +344,62 @@ services:
 	}
 }
 
+func TestLoadNonNumericPort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	manifest := []byte(`version: 0.1
+stack:
+  name: demo
+services:
+  api:
+    image: test
+    runtime: docker
+    ports: ["abc:8080"]
+    health:
+      tcp:
+        address: localhost:8080
+`)
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "port numbers must be numeric") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadOutOfRangePort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	manifest := []byte(`version: 0.1
+stack:
+  name: demo
+services:
+  api:
+    image: test
+    runtime: docker
+    ports: ["70000:8080"]
+    health:
+      tcp:
+        address: localhost:8080
+`)
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "port numbers must be numeric") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func equalIntSlices(a, b []int) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -270,6 +271,15 @@ func validatePort(spec string) error {
 	}
 	if strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
 		return fmt.Errorf("invalid port mapping %q (expected host:container or host:container/proto)", spec)
+	}
+	for _, segment := range []string{parts[0], parts[1]} {
+		port, err := strconv.Atoi(segment)
+		if err != nil {
+			return fmt.Errorf("invalid port mapping %q (port numbers must be numeric in range 1-65535)", spec)
+		}
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("invalid port mapping %q (port numbers must be numeric in range 1-65535)", spec)
+		}
 	}
 	if proto != "" {
 		protoLower := strings.ToLower(proto)


### PR DESCRIPTION
## Summary
- ensure service port mappings contain numeric host and container ports within the valid range
- add loader tests covering alphabetic and out-of-range port specifications

## Testing
- go test ./internal/config -run TestLoadNonNumericPort -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68e07cc2b1ec83258f68ecda1f4f6fd0