### PR TITLE
Add runtime wait monitoring and supervisor exit handling

### DIFF
--- a/internal/cli/up_integration_test.go
+++ b/internal/cli/up_integration_test.go
@@ -300,6 +300,15 @@ func (i *blockingInstance) WaitReady(ctx stdcontext.Context) error {
 	}
 }
 
+func (i *blockingInstance) Wait(ctx stdcontext.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-i.runtime.stopRelease:
+		return nil
+	}
+}
+
 func (i *blockingInstance) Health() <-chan probe.State {
 	return nil
 }
@@ -445,6 +454,16 @@ func (i *mockInstance) WaitReady(ctx stdcontext.Context) error {
 		}
 		i.runtime.recordReady(i.name)
 		return nil
+	}
+}
+
+func (i *mockInstance) Wait(ctx stdcontext.Context) error {
+	if i.waitErr != nil {
+		return i.waitErr
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/engine/supervisor_test.go
+++ b/internal/engine/supervisor_test.go
@@ -280,6 +280,14 @@ func (f *fakeInstance) WaitReady(ctx context.Context) error {
 	}
 }
 
+func (f *fakeInstance) Wait(ctx context.Context) error {
+	if f.waitErr != nil {
+		return f.waitErr
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
 func (f *fakeInstance) Health() <-chan probe.State {
 	return f.healthCh
 }

--- a/internal/runtime/process/process_test.go
+++ b/internal/runtime/process/process_test.go
@@ -202,8 +202,7 @@ func TestStartPreservesBaseEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start service: %v", err)
 	}
-	procInst, ok := inst.(*processInstance)
-	if !ok {
+	if _, ok := inst.(*processInstance); !ok {
 		t.Fatalf("expected *processInstance, got %T", inst)
 	}
 
@@ -224,13 +223,13 @@ func TestStartPreservesBaseEnvironment(t *testing.T) {
 		t.Fatalf("timed out waiting for log output")
 	}
 
-	select {
-	case err := <-procInst.waitErr:
-		if err != nil {
-			t.Fatalf("process exited with error: %v", err)
+	{
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		waitErr := inst.Wait(waitCtx)
+		waitCancel()
+		if waitErr != nil {
+			t.Fatalf("process exited with error: %v", waitErr)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timed out waiting for process exit")
 	}
 }
 
@@ -256,18 +255,17 @@ func TestStartSetsWorkingDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start service: %v", err)
 	}
-	procInst, ok := inst.(*processInstance)
-	if !ok {
+	if _, ok := inst.(*processInstance); !ok {
 		t.Fatalf("expected *processInstance, got %T", inst)
 	}
 
-	select {
-	case err := <-procInst.waitErr:
-		if err != nil {
-			t.Fatalf("process exited with error: %v", err)
+	{
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		waitErr := inst.Wait(waitCtx)
+		waitCancel()
+		if waitErr != nil {
+			t.Fatalf("process exited with error: %v", waitErr)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timed out waiting for process exit")
 	}
 
 	data, err := os.ReadFile(outputPath)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -15,6 +15,12 @@ type Instance interface {
 	// provided context is cancelled.
 	WaitReady(ctx context.Context) error
 
+	// Wait blocks until the instance exits or the provided context is
+	// cancelled. Implementations should return any error associated with
+	// the termination of the underlying process/container. A nil error
+	// indicates a clean shutdown.
+	Wait(ctx context.Context) error
+
 	// Health returns a channel that delivers readiness transitions for the
 	// instance. A nil channel indicates that the runtime does not surface
 	// health information beyond the initial readiness gate.


### PR DESCRIPTION
## Summary
- add a Wait hook to runtime.Instance and implement it for the docker and process runtimes
- track process exit state to unblock Wait/Stop reliably and surface clean vs. error exits
- watch the new Wait channel in the supervisor so unexpected exits emit crash events and trigger restarts, updating tests and mocks for the new API

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e08d9629888325a41731c0e6e2c10b