### PR TITLE
Refactor runtime interface and update Docker runtime

### DIFF
--- a/internal/engine/orchestrator_test.go
+++ b/internal/engine/orchestrator_test.go
@@ -292,9 +292,10 @@ func newRecordingRuntime(instances map[string]*fakeInstance) *recordingRuntime {
 	}
 }
 
-func (r *recordingRuntime) Start(ctx context.Context, name string, svc *stack.Service) (runtimelib.Instance, error) {
+func (r *recordingRuntime) Start(ctx context.Context, spec runtimelib.StartSpec) (runtimelib.Handle, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	name := spec.Name
 	inst, ok := r.instances[name]
 	if !ok {
 		return nil, fmt.Errorf("no instance configured for service %s", name)

--- a/internal/engine/supervisor_test.go
+++ b/internal/engine/supervisor_test.go
@@ -232,7 +232,7 @@ type fakeRuntime struct {
 	startCh   chan struct{}
 }
 
-func (f *fakeRuntime) Start(ctx context.Context, name string, svc *stack.Service) (runtime.Instance, error) {
+func (f *fakeRuntime) Start(ctx context.Context, spec runtime.StartSpec) (runtime.Handle, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if len(f.instances) == 0 {
@@ -311,6 +311,10 @@ func (f *fakeInstance) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (f *fakeInstance) Logs() <-chan runtime.LogEntry {
-	return f.logsCh
+func (f *fakeInstance) Kill(ctx context.Context) error {
+	return f.Stop(ctx)
+}
+
+func (f *fakeInstance) Logs(ctx context.Context) (<-chan runtime.LogEntry, error) {
+	return f.logsCh, nil
 }

--- a/internal/runtime/docker/docker_integration_test.go
+++ b/internal/runtime/docker/docker_integration_test.go
@@ -42,7 +42,17 @@ func TestRuntimeStartStopLogs(t *testing.T) {
 		Command: []string{"sh", "-c", "while true; do echo orco-ready; sleep 1; done"},
 	}
 
-	inst, err := rt.Start(ctx, "log-loop", svc)
+	spec := runtime.StartSpec{
+		Name:    "log-loop",
+		Image:   svc.Image,
+		Command: svc.Command,
+		Env:     svc.Env,
+		Ports:   svc.Ports,
+		Health:  svc.Health,
+		Service: svc,
+	}
+
+	inst, err := rt.Start(ctx, spec)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -56,7 +66,10 @@ func TestRuntimeStartStopLogs(t *testing.T) {
 		t.Fatalf("wait ready: %v", err)
 	}
 
-	logs := inst.Logs()
+	logs, err := inst.Logs(ctx)
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
 	if logs == nil {
 		t.Fatal("logs channel is nil")
 	}
@@ -116,7 +129,17 @@ func TestRuntimeHTTPHealth(t *testing.T) {
 		},
 	}
 
-	inst, err := rt.Start(ctx, "nginx", svc)
+	spec := runtime.StartSpec{
+		Name:    "nginx",
+		Image:   svc.Image,
+		Command: svc.Command,
+		Env:     svc.Env,
+		Ports:   svc.Ports,
+		Health:  svc.Health,
+		Service: svc,
+	}
+
+	inst, err := rt.Start(ctx, spec)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -172,7 +195,17 @@ func TestRuntimeContainerExitSurfaced(t *testing.T) {
 		Command: []string{"sh", "-c", "exit 2"},
 	}
 
-	inst, err := rt.Start(ctx, "exit", svc)
+	spec := runtime.StartSpec{
+		Name:    "exit",
+		Image:   svc.Image,
+		Command: svc.Command,
+		Env:     svc.Env,
+		Ports:   svc.Ports,
+		Health:  svc.Health,
+		Service: svc,
+	}
+
+	inst, err := rt.Start(ctx, spec)
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}

--- a/internal/runtime/process/process_test.go
+++ b/internal/runtime/process/process_test.go
@@ -198,7 +198,16 @@ func TestStartPreservesBaseEnvironment(t *testing.T) {
 		Command: []string{"/bin/sh", "-c", "echo $PATH"},
 	}
 
-	inst, err := New().Start(context.Background(), "env-check", svc)
+	spec := runtimelib.StartSpec{
+		Name:    "env-check",
+		Command: svc.Command,
+		Env:     svc.Env,
+		Workdir: svc.ResolvedWorkdir,
+		Health:  svc.Health,
+		Service: svc,
+	}
+
+	inst, err := New().Start(context.Background(), spec)
 	if err != nil {
 		t.Fatalf("start service: %v", err)
 	}
@@ -206,7 +215,10 @@ func TestStartPreservesBaseEnvironment(t *testing.T) {
 		t.Fatalf("expected *processInstance, got %T", inst)
 	}
 
-	logs := inst.Logs()
+	logs, err := inst.Logs(context.Background())
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
 	if logs == nil {
 		t.Fatalf("logs channel is nil")
 	}
@@ -251,7 +263,16 @@ func TestStartSetsWorkingDirectory(t *testing.T) {
 		ResolvedWorkdir: workdir,
 	}
 
-	inst, err := New().Start(context.Background(), "workdir-check", svc)
+	spec := runtimelib.StartSpec{
+		Name:    "workdir-check",
+		Command: svc.Command,
+		Env:     svc.Env,
+		Workdir: svc.ResolvedWorkdir,
+		Health:  svc.Health,
+		Service: svc,
+	}
+
+	inst, err := New().Start(context.Background(), spec)
 	if err != nil {
 		t.Fatalf("start service: %v", err)
 	}
@@ -307,7 +328,16 @@ func TestStopTerminatesProcessGroup(t *testing.T) {
 		Command: []string{scriptPath, parentPIDPath, childPIDPath},
 	}
 
-	inst, err := New().Start(context.Background(), "process-group", svc)
+	spec := runtimelib.StartSpec{
+		Name:    "process-group",
+		Command: svc.Command,
+		Env:     svc.Env,
+		Workdir: svc.ResolvedWorkdir,
+		Health:  svc.Health,
+		Service: svc,
+	}
+
+	inst, err := New().Start(context.Background(), spec)
 	if err != nil {
 		t.Fatalf("start service: %v", err)
 	}

--- a/internal/runtime/process/stop_unix.go
+++ b/internal/runtime/process/stop_unix.go
@@ -11,22 +11,32 @@ import (
 )
 
 func (p *processInstance) Stop(ctx context.Context) error {
+	return p.terminate(ctx, false)
+}
+
+func (p *processInstance) Kill(ctx context.Context) error {
+	return p.terminate(ctx, true)
+}
+
+func (p *processInstance) terminate(ctx context.Context, force bool) error {
 	p.cancelWatch()
 	if p.cmd.Process == nil {
 		return nil
 	}
 
-	// Attempt a graceful shutdown first.
-	if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
-		return fmt.Errorf("signal process group %s: %w", p.name, err)
-	}
+	if !force {
+		// Attempt a graceful shutdown first.
+		if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return fmt.Errorf("signal process group %s: %w", p.name, err)
+		}
 
-	select {
-	case <-p.waitDone:
-		return p.exitError()
-	case <-time.After(2 * time.Second):
-	case <-ctx.Done():
-		return ctx.Err()
+		select {
+		case <-p.waitDone:
+			return p.exitError()
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {


### PR DESCRIPTION
## Summary
- introduce the new runtime.Handle API with StartSpec describing launch parameters
- update Docker and process runtimes to consume StartSpec, expose context-aware log streaming, and add Kill support
- adjust the engine supervisor and tests to work with the new runtime API

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e12a1e4a8c8325880b4c864fce87c1