### PR TITLE
Update module path to github.com/Paintersrp/orco

### DIFF
--- a/cmd/orco/main.go
+++ b/cmd/orco/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/example/orco/internal/cli"
+import "github.com/Paintersrp/orco/internal/cli"
 
 func main() {
 	cli.Execute()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/example/orco
+module github.com/Paintersrp/orco
 
 go 1.24.0
 
@@ -10,6 +10,7 @@ require (
 	github.com/gdamore/tcell/v2 v2.8.1
 	github.com/rivo/tview v0.42.0
 	github.com/spf13/cobra v1.7.0
+	golang.org/x/term v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -32,7 +33,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/example/orco/internal/config"
+	"github.com/Paintersrp/orco/internal/config"
 )
 
 func newConfigCmd() *cobra.Command {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/example/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/engine"
 )
 
 func newDownCmd(ctx *context) *cobra.Command {

--- a/internal/cli/down_integration_test.go
+++ b/internal/cli/down_integration_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/example/orco/internal/engine"
-	"github.com/example/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/runtime"
 )
 
 func TestDownCommandStopsServicesInReverseOrder(t *testing.T) {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/example/orco/internal/cliutil"
-	"github.com/example/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/cliutil"
+	"github.com/Paintersrp/orco/internal/engine"
 )
 
 func newLogsCmd(ctx *context) *cobra.Command {

--- a/internal/cli/logs_integration_test.go
+++ b/internal/cli/logs_integration_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/example/orco/internal/engine"
-	runtimelib "github.com/example/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/engine"
+	runtimelib "github.com/Paintersrp/orco/internal/runtime"
 )
 
 func TestLogsCommandStreamsStructuredOutput(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/example/orco/internal/cliutil"
-	"github.com/example/orco/internal/engine"
-	"github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/runtime/docker"
-	"github.com/example/orco/internal/runtime/process"
+	"github.com/Paintersrp/orco/internal/cliutil"
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/runtime/docker"
+	"github.com/Paintersrp/orco/internal/runtime/process"
 )
 
 func NewRootCmd() *cobra.Command {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -12,9 +12,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/example/orco/internal/cliutil"
-	"github.com/example/orco/internal/engine"
-	"github.com/example/orco/internal/tui"
+	"github.com/Paintersrp/orco/internal/cliutil"
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/tui"
 )
 
 func newUpCmd(ctx *context) *cobra.Command {

--- a/internal/cli/up_integration_test.go
+++ b/internal/cli/up_integration_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/example/orco/internal/engine"
-	"github.com/example/orco/internal/probe"
-	"github.com/example/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/runtime"
 )
 
 func TestUpCommandStartsServicesInDependencyOrder(t *testing.T) {

--- a/internal/cliutil/logfmt.go
+++ b/internal/cliutil/logfmt.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/example/orco/internal/engine"
-	"github.com/example/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/runtime"
 )
 
 // LogRecord represents a structured log event ready for JSON encoding.

--- a/internal/cliutil/stack.go
+++ b/internal/cliutil/stack.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/example/orco/internal/config"
-	"github.com/example/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/config"
+	"github.com/Paintersrp/orco/internal/engine"
 )
 
 // StackDocument bundles a parsed stack file with the derived dependency graph.

--- a/internal/engine/dag.go
+++ b/internal/engine/dag.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 // Graph represents service dependencies.

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 // EventType captures high level lifecycle notifications emitted by the

--- a/internal/engine/orchestrator_test.go
+++ b/internal/engine/orchestrator_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	runtimelib "github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	runtimelib "github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func TestOrchestratorGatesOnStartedRequirement(t *testing.T) {

--- a/internal/engine/supervisor.go
+++ b/internal/engine/supervisor.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/example/orco/internal/probe"
-	"github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 const (

--- a/internal/engine/supervisor_test.go
+++ b/internal/engine/supervisor_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/example/orco/internal/probe"
-	"github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func TestSupervisorRestartsOnUnready(t *testing.T) {

--- a/internal/probe/cmd.go
+++ b/internal/probe/cmd.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os/exec"
 
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 type commandProber struct {

--- a/internal/probe/http.go
+++ b/internal/probe/http.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 type httpProber struct {

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 // Status captures the readiness condition surfaced by a probe watcher.

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func TestWatchHTTPTransitions(t *testing.T) {

--- a/internal/probe/tcp.go
+++ b/internal/probe/tcp.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 type tcpProber struct {

--- a/internal/runtime/docker/docker.go
+++ b/internal/runtime/docker/docker.go
@@ -19,9 +19,9 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 
-	"github.com/example/orco/internal/probe"
-	"github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 type runtimeImpl struct {

--- a/internal/runtime/docker/docker_integration_test.go
+++ b/internal/runtime/docker/docker_integration_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/client"
 
-	"github.com/example/orco/internal/probe"
-	"github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func closedChan() chan struct{} {

--- a/internal/runtime/process/process.go
+++ b/internal/runtime/process/process.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/example/orco/internal/probe"
-	"github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 type runtimeImpl struct{}

--- a/internal/runtime/process/process_test.go
+++ b/internal/runtime/process/process_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/example/orco/internal/engine"
-	runtimelib "github.com/example/orco/internal/runtime"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/engine"
+	runtimelib "github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func TestWaitReadyBlocksUntilProbeSuccess(t *testing.T) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/example/orco/internal/probe"
-	"github.com/example/orco/internal/stack"
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 // Handle represents a single running service instance managed by a runtime

--- a/internal/stack/types.go
+++ b/internal/stack/types.go
@@ -1,6 +1,6 @@
 package stack
 
-import "github.com/example/orco/internal/config"
+import "github.com/Paintersrp/orco/internal/config"
 
 type (
 	Duration      = config.Duration

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -13,8 +13,8 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
-	"github.com/example/orco/internal/cliutil"
-	"github.com/example/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/cliutil"
+	"github.com/Paintersrp/orco/internal/engine"
 )
 
 const (


### PR DESCRIPTION
## Summary
- update the module declaration to github.com/Paintersrp/orco
- switch all internal imports to the new module path
- tidy module metadata after the path update

## Testing
- go mod tidy
- go test ./... *(hangs waiting for integration tests that require Docker, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68e138f079c8832584aed52766901b5d