### PR TITLE
Ensure Docker wait captures exit status

### DIFF
--- a/internal/runtime/docker/docker_integration_test.go
+++ b/internal/runtime/docker/docker_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -227,6 +228,14 @@ func TestRuntimeContainerExitSurfaced(t *testing.T) {
 
 	if err := inst.WaitReady(ctx); err == nil {
 		t.Fatal("expected wait ready error")
+	}
+
+	waitErr := inst.Wait(ctx)
+	if waitErr == nil {
+		t.Fatal("expected wait error")
+	}
+	if !strings.Contains(waitErr.Error(), "status 2") {
+		t.Fatalf("expected wait error to contain exit status, got %v", waitErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the Docker wait goroutine listening to both status and error channels so exit status is captured reliably
- surface combined Docker exit status and error messages when available
- extend the exit surfacing integration test to cover Handle.Wait returning an error on non-zero exits

## Testing
- go test ./... (hangs waiting for Docker; aborted)


------
https://chatgpt.com/codex/tasks/task_e_68e13b37018c8325939c664aa1de8371