### PR TITLE
Add attempt metadata to engine lifecycle events

### DIFF
--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -32,9 +32,25 @@ type Event struct {
 	Level     string
 	Source    string
 	Err       error
+	Attempt   int
+	Reason    string
 }
 
-func sendEvent(events chan<- Event, service string, t EventType, message string, err error) {
+const (
+	ReasonInitialStart   = "initial_start"
+	ReasonRestart        = "restart"
+	ReasonStartFailure   = "start_failure"
+	ReasonInstanceCrash  = "instance_crash"
+	ReasonRetriesExhaust = "retries_exhausted"
+	ReasonLogStreamError = "log_stream_error"
+	ReasonProbeReady     = "probe_ready"
+	ReasonProbeUnready   = "probe_unready"
+	ReasonSupervisorStop = "supervisor_stop"
+	ReasonStopFailed     = "stop_failed"
+	ReasonShutdown       = "shutdown"
+)
+
+func sendEvent(events chan<- Event, service string, t EventType, message string, attempt int, reason string, err error) {
 	if events == nil {
 		return
 	}
@@ -47,5 +63,7 @@ func sendEvent(events chan<- Event, service string, t EventType, message string,
 		Level:     "info",
 		Source:    runtime.LogSourceSystem,
 		Err:       err,
+		Attempt:   attempt,
+		Reason:    reason,
 	}
 }

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -168,9 +168,9 @@ func (d *Deployment) Stop(ctx context.Context, events chan<- Event) error {
 		var firstErr error
 		for i := len(d.handles) - 1; i >= 0; i-- {
 			handle := d.handles[i]
-			sendEvent(events, handle.name, EventTypeStopping, "stopping service", nil)
+			sendEvent(events, handle.name, EventTypeStopping, "stopping service", 0, ReasonShutdown, nil)
 			if err := handle.supervisor.Stop(ctx); err != nil {
-				sendEvent(events, handle.name, EventTypeError, "stop failed", err)
+				sendEvent(events, handle.name, EventTypeError, "stop failed", 0, ReasonStopFailed, err)
 				if firstErr == nil {
 					firstErr = fmt.Errorf("stop service %s: %w", handle.name, err)
 				}


### PR DESCRIPTION
## Summary
- add attempt and reason metadata to engine lifecycle events
- propagate attempt counts and reason constants through supervisor and orchestrator emitters
- extend supervisor and orchestrator tests to validate lifecycle attempt information

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e16c0cfa188325b01f90196dc3442b