### PR TITLE
Emit blocked events for dependency waits

### DIFF
--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -20,6 +20,7 @@ const (
 	EventTypeUnready  EventType = "unready"
 	EventTypeCrashed  EventType = "crashed"
 	EventTypeFailed   EventType = "failed"
+	EventTypeBlocked  EventType = "blocked"
 )
 
 // Event represents a single lifecycle or log notification.
@@ -37,17 +38,18 @@ type Event struct {
 }
 
 const (
-	ReasonInitialStart   = "initial_start"
-	ReasonRestart        = "restart"
-	ReasonStartFailure   = "start_failure"
-	ReasonInstanceCrash  = "instance_crash"
-	ReasonRetriesExhaust = "retries_exhausted"
-	ReasonLogStreamError = "log_stream_error"
-	ReasonProbeReady     = "probe_ready"
-	ReasonProbeUnready   = "probe_unready"
-	ReasonSupervisorStop = "supervisor_stop"
-	ReasonStopFailed     = "stop_failed"
-	ReasonShutdown       = "shutdown"
+	ReasonInitialStart      = "initial_start"
+	ReasonRestart           = "restart"
+	ReasonStartFailure      = "start_failure"
+	ReasonInstanceCrash     = "instance_crash"
+	ReasonRetriesExhaust    = "retries_exhausted"
+	ReasonLogStreamError    = "log_stream_error"
+	ReasonProbeReady        = "probe_ready"
+	ReasonProbeUnready      = "probe_unready"
+	ReasonSupervisorStop    = "supervisor_stop"
+	ReasonStopFailed        = "stop_failed"
+	ReasonShutdown          = "shutdown"
+	ReasonDependencyBlocked = "dependency_blocked"
 )
 
 func sendEvent(events chan<- Event, service string, t EventType, message string, attempt int, reason string, err error) {

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -137,6 +137,15 @@ func (o *Orchestrator) Up(ctx context.Context, doc *stack.StackFile, graph *Grap
 			}
 			if err != nil {
 				blockErr := fmt.Errorf("service %s blocked waiting for %s (%s): %w", name, dep.Target, require, err)
+				sendEvent(
+					events,
+					name,
+					EventTypeBlocked,
+					fmt.Sprintf("blocked waiting for %s (%s)", dep.Target, require),
+					0,
+					fmt.Sprintf("%s: %v", ReasonDependencyBlocked, blockErr),
+					blockErr,
+				)
 				if cleanupErr := cleanupDeployment(deployment, events); cleanupErr != nil {
 					blockErr = fmt.Errorf("%w (cleanup failed: %v)", blockErr, cleanupErr)
 				}


### PR DESCRIPTION
## Summary
- add an EventTypeBlocked lifecycle type and dependency_blocked reason for orchestrator events
- emit a blocked event with context when dependencies fail to reach the required state
- extend orchestrator dependency failure tests to assert blocked events for readiness errors and timeouts

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1742b9b188325bfbbaddcc8c10baa