### PR TITLE
Handle nil stack file in BuildGraph

### DIFF
--- a/internal/engine/dag.go
+++ b/internal/engine/dag.go
@@ -1,11 +1,14 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/Paintersrp/orco/internal/stack"
 )
+
+var errNilStackFile = errors.New("cannot build graph from a nil stack file")
 
 // Graph represents service dependencies.
 type Graph struct {
@@ -17,6 +20,10 @@ type Graph struct {
 
 // BuildGraph constructs the dependency graph and validates acyclicity.
 func BuildGraph(doc *stack.StackFile) (*Graph, error) {
+	if doc == nil {
+		return nil, errNilStackFile
+	}
+
 	g := &Graph{
 		services: make(map[string]*stack.Service, len(doc.Services)),
 		edges:    make(map[string][]string, len(doc.Services)),

--- a/internal/engine/dag_test.go
+++ b/internal/engine/dag_test.go
@@ -1,0 +1,15 @@
+package engine
+
+import "testing"
+
+func TestBuildGraphNilStackFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildGraph(nil)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err != errNilStackFile {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated error for nil stack files and guard BuildGraph against nil input
- add a regression test covering BuildGraph(nil)

## Testing
- go test ./internal/engine

------
https://chatgpt.com/codex/tasks/task_e_68e1771a693c8325b6407a8071d061c4