### PR TITLE
Infer log levels from log messages

### DIFF
--- a/internal/cliutil/logfmt_test.go
+++ b/internal/cliutil/logfmt_test.go
@@ -1,0 +1,76 @@
+package cliutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+func TestEncodeLogEventInfersLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{name: "errorToken", message: "[ERROR] failed to start", expected: "error"},
+		{name: "warnToken", message: "WARN service requires attention", expected: "warn"},
+		{name: "infoToken", message: "info: service ready", expected: "info"},
+		{name: "noTokenDefaults", message: "service started", expected: "info"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			var errBuf bytes.Buffer
+
+			event := engine.Event{
+				Timestamp: time.Unix(0, 0),
+				Message:   tc.message,
+			}
+
+			EncodeLogEvent(json.NewEncoder(&out), &errBuf, event)
+
+			if errBuf.Len() != 0 {
+				t.Fatalf("unexpected stderr output: %s", errBuf.String())
+			}
+
+			var record LogRecord
+			if err := json.Unmarshal(out.Bytes(), &record); err != nil {
+				t.Fatalf("failed to unmarshal log record: %v", err)
+			}
+
+			if record.Level != tc.expected {
+				t.Fatalf("expected level %q, got %q", tc.expected, record.Level)
+			}
+		})
+	}
+}
+
+func TestEncodeLogEventKeepsProvidedLevel(t *testing.T) {
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+
+	event := engine.Event{
+		Timestamp: time.Unix(0, 0),
+		Message:   "custom level",
+		Level:     "debug",
+	}
+
+	EncodeLogEvent(json.NewEncoder(&out), &errBuf, event)
+
+	if errBuf.Len() != 0 {
+		t.Fatalf("unexpected stderr output: %s", errBuf.String())
+	}
+
+	var record LogRecord
+	if err := json.Unmarshal(out.Bytes(), &record); err != nil {
+		t.Fatalf("failed to unmarshal log record: %v", err)
+	}
+
+	if record.Level != "debug" {
+		t.Fatalf("expected level %q, got %q", "debug", record.Level)
+	}
+}


### PR DESCRIPTION
## Summary
- infer log levels from message tokens when events arrive without a level
- add regression tests ensuring EncodeLogEvent emits inferred levels and keeps explicit levels

## Testing
- go test ./internal/cliutil -run TestEncodeLogEvent -count=1


------
https://chatgpt.com/codex/tasks/task_e_68e1899a83488325904e02c52ca48098