### PR TITLE
Normalize log levels in log mux

### DIFF
--- a/internal/logmux/mux_test.go
+++ b/internal/logmux/mux_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/runtime"
 )
 
 func TestMuxFansInMultipleSources(t *testing.T) {
@@ -28,26 +29,36 @@ func TestMuxFansInMultipleSources(t *testing.T) {
 
 	go mux.Close()
 
-	var services []string
-	var messages []string
+	var events []engine.Event
 	for evt := range mux.Output() {
-		services = append(services, evt.Service)
-		messages = append(messages, evt.Message)
+		events = append(events, evt)
 	}
 
-	if len(messages) != 3 {
-		t.Fatalf("expected 3 events, got %d", len(messages))
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
 	}
 
-	expectedServices := []string{"api", "api", "worker"}
-	expectedMessages := []string{"api ready", "api ok", "worker ready"}
-	for i := range expectedServices {
-		if services[i] != expectedServices[i] {
-			t.Fatalf("event %d service mismatch: got %s want %s", i, services[i], expectedServices[i])
+	var apiMessages []string
+	var workerMessages []string
+	for _, evt := range events {
+		switch evt.Service {
+		case "api":
+			apiMessages = append(apiMessages, evt.Message)
+		case "worker":
+			workerMessages = append(workerMessages, evt.Message)
+		default:
+			t.Fatalf("unexpected service %s", evt.Service)
 		}
-		if messages[i] != expectedMessages[i] {
-			t.Fatalf("event %d message mismatch: got %s want %s", i, messages[i], expectedMessages[i])
-		}
+	}
+
+	if len(apiMessages) != 2 {
+		t.Fatalf("expected 2 api events, got %d", len(apiMessages))
+	}
+	if apiMessages[0] != "api ready" || apiMessages[1] != "api ok" {
+		t.Fatalf("api messages out of order: %v", apiMessages)
+	}
+	if len(workerMessages) != 1 || workerMessages[0] != "worker ready" {
+		t.Fatalf("unexpected worker messages: %v", workerMessages)
 	}
 }
 
@@ -98,5 +109,45 @@ func TestMuxEmitsDropMetaEvents(t *testing.T) {
 	}
 	if time.Since(meta.Timestamp) > time.Second {
 		t.Fatalf("expected recent timestamp, got %v", meta.Timestamp)
+	}
+}
+
+func TestMuxNormalizesLevelsFromMessages(t *testing.T) {
+	mux := New(4)
+	src := make(chan engine.Event, 3)
+
+	mux.Add(src)
+
+	go func() {
+		src <- engine.Event{Service: "api", Type: engine.EventTypeLog, Message: "ERROR: failure"}
+		src <- engine.Event{Service: "api", Type: engine.EventTypeLog, Message: "INFO: all good", Level: "warn", Source: runtime.LogSourceStderr}
+		src <- engine.Event{Service: "api", Type: engine.EventTypeLog, Message: "plain"}
+		close(src)
+	}()
+
+	go mux.Close()
+
+	var events []engine.Event
+	for evt := range mux.Output() {
+		events = append(events, evt)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	if events[0].Level != "error" {
+		t.Fatalf("expected first event level error, got %s", events[0].Level)
+	}
+	if events[1].Level != "info" {
+		t.Fatalf("expected second event level info, got %s", events[1].Level)
+	}
+	if events[2].Level != "info" {
+		t.Fatalf("expected third event level info, got %s", events[2].Level)
+	}
+	for i, evt := range events {
+		if evt.Source == "" {
+			t.Fatalf("event %d expected normalized source, got empty", i)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- normalize log levels inside the log mux using token detection so the NDJSON stream reports consistent levels
- expand mux tests to cover per-service ordering, fan-in behaviour, and message-derived level normalization

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e18c92e5e88325a635da2dcfebbfcd