### PR TITLE
Add runtime-backed status reporting to CLI

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -64,6 +65,10 @@ func Execute() {
 type context struct {
 	stackFile    *string
 	orchestrator *engine.Orchestrator
+
+	mu         sync.RWMutex
+	deployment *engine.Deployment
+	tracker    *statusTracker
 }
 
 func (c *context) loadStack() (*cliutil.StackDocument, error) {
@@ -78,4 +83,51 @@ func (c *context) getOrchestrator() *engine.Orchestrator {
 		})
 	}
 	return c.orchestrator
+}
+
+func (c *context) setDeployment(dep *engine.Deployment) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deployment = dep
+}
+
+func (c *context) clearDeployment(dep *engine.Deployment) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.deployment == dep {
+		c.deployment = nil
+	}
+}
+
+func (c *context) currentDeployment() *engine.Deployment {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.deployment
+}
+
+func (c *context) statusTracker() *statusTracker {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.tracker == nil {
+		c.tracker = newStatusTracker()
+	}
+	return c.tracker
+}
+
+func (c *context) trackEvents(events <-chan engine.Event, buffer int) <-chan engine.Event {
+	tracker := c.statusTracker()
+	var out chan engine.Event
+	if buffer > 0 {
+		out = make(chan engine.Event, buffer)
+	} else {
+		out = make(chan engine.Event)
+	}
+	go func() {
+		defer close(out)
+		for evt := range events {
+			tracker.Apply(evt)
+			out <- evt
+		}
+	}()
+	return out
 }

--- a/internal/cli/status_command_test.go
+++ b/internal/cli/status_command_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"bytes"
+	stdcontext "context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+func TestStatusCommandReflectsBlockedAndReadyTransitions(t *testing.T) {
+	t.Parallel()
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  api:
+    runtime: process
+    command: ["sleep", "0"]
+  db:
+    runtime: process
+    command: ["sleep", "0"]
+`)
+
+	ctx := &context{stackFile: &stackPath}
+	tracker := ctx.statusTracker()
+
+	base := time.Now().Add(-2 * time.Minute)
+	tracker.Apply(engine.Event{Service: "db", Type: engine.EventTypeReady, Message: "database ready", Timestamp: base})
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeBlocked, Message: "waiting for db", Timestamp: base.Add(30 * time.Second)})
+
+	output := runStatusCommand(t, ctx)
+	if !strings.Contains(output, "SERVICE") || !strings.Contains(output, "STATE") {
+		t.Fatalf("expected status header, got: %s", output)
+	}
+
+	apiLine := findServiceLine(output, "api")
+	if !strings.Contains(apiLine, "Blocked") {
+		t.Fatalf("expected api line to show blocked, got: %s", apiLine)
+	}
+	if !strings.Contains(apiLine, "No") {
+		t.Fatalf("expected api line to show ready=No, got: %s", apiLine)
+	}
+	if !strings.Contains(apiLine, "waiting for db") {
+		t.Fatalf("expected api message in output, got: %s", apiLine)
+	}
+
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeReady, Message: "service ready", Timestamp: base.Add(90 * time.Second)})
+
+	output = runStatusCommand(t, ctx)
+	apiLine = findServiceLine(output, "api")
+	if !strings.Contains(apiLine, "Ready") {
+		t.Fatalf("expected api line to show ready state, got: %s", apiLine)
+	}
+	if !strings.Contains(apiLine, "Yes") {
+		t.Fatalf("expected api line to show ready=Yes, got: %s", apiLine)
+	}
+	if !strings.Contains(apiLine, "service ready") {
+		t.Fatalf("expected api ready message, got: %s", apiLine)
+	}
+
+	dbLine := findServiceLine(output, "db")
+	if !strings.Contains(dbLine, "Ready") {
+		t.Fatalf("expected db to remain ready, got: %s", dbLine)
+	}
+}
+
+func runStatusCommand(t *testing.T, ctx *context) string {
+	t.Helper()
+	cmd := newStatusCmd(ctx)
+	cmd.SetContext(stdcontext.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status command failed: %v\nstderr: %s", err, stderr.String())
+	}
+	return stdout.String()
+}
+
+func findServiceLine(output, service string) string {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, service+" ") || trimmed == service {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/cli/status_tracker.go
+++ b/internal/cli/status_tracker.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+// serviceStatus captures runtime state for a service observed via events.
+type serviceStatus struct {
+	name      string
+	firstSeen time.Time
+	lastEvent time.Time
+	state     engine.EventType
+	ready     bool
+	restarts  int
+	message   string
+}
+
+// statusTracker maintains in-memory status for services based on engine events.
+type statusTracker struct {
+	mu       sync.RWMutex
+	services map[string]*serviceStatus
+}
+
+func newStatusTracker() *statusTracker {
+	return &statusTracker{services: make(map[string]*serviceStatus)}
+}
+
+// Apply updates the tracker based on the supplied event.
+func (t *statusTracker) Apply(evt engine.Event) {
+	if evt.Timestamp.IsZero() {
+		evt.Timestamp = time.Now()
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	state := t.services[evt.Service]
+	if state == nil {
+		state = &serviceStatus{name: evt.Service, firstSeen: evt.Timestamp}
+		t.services[evt.Service] = state
+	}
+	if state.firstSeen.IsZero() {
+		state.firstSeen = evt.Timestamp
+	}
+	state.lastEvent = evt.Timestamp
+
+	if evt.Type != engine.EventTypeLog {
+		state.state = evt.Type
+		switch evt.Type {
+		case engine.EventTypeReady:
+			state.ready = true
+		case engine.EventTypeUnready, engine.EventTypeStopping, engine.EventTypeStopped,
+			engine.EventTypeCrashed, engine.EventTypeFailed, engine.EventTypeBlocked:
+			state.ready = false
+		}
+		if evt.Type == engine.EventTypeCrashed {
+			state.restarts++
+		}
+		if evt.Message != "" {
+			state.message = evt.Message
+		} else if evt.Err != nil {
+			state.message = evt.Err.Error()
+		} else {
+			state.message = ""
+		}
+	}
+}
+
+// ServiceStatus captures a snapshot of a service state for presentation.
+type ServiceStatus struct {
+	Name      string
+	FirstSeen time.Time
+	LastEvent time.Time
+	State     engine.EventType
+	Ready     bool
+	Restarts  int
+	Message   string
+}
+
+// Snapshot returns a map keyed by service name containing copies of the tracked state.
+func (t *statusTracker) Snapshot() map[string]ServiceStatus {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	snapshot := make(map[string]ServiceStatus, len(t.services))
+	for name, state := range t.services {
+		snapshot[name] = ServiceStatus{
+			Name:      state.name,
+			FirstSeen: state.firstSeen,
+			LastEvent: state.lastEvent,
+			State:     state.state,
+			Ready:     state.ready,
+			Restarts:  state.restarts,
+			Message:   state.message,
+		}
+	}
+	return snapshot
+}
+
+// Names returns the list of known services sorted alphabetically. Useful for tests.
+func (t *statusTracker) Names() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	names := make([]string, 0, len(t.services))
+	for name := range t.services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/cli/status_tracker_test.go
+++ b/internal/cli/status_tracker_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+func TestStatusTrackerUpdatesReadyAndBlockedState(t *testing.T) {
+	t.Parallel()
+
+	tracker := newStatusTracker()
+	base := time.Now().Add(-10 * time.Second)
+
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeStarting, Timestamp: base})
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeBlocked, Message: "waiting", Timestamp: base.Add(time.Second)})
+
+	snapshot := tracker.Snapshot()["api"]
+	if snapshot.State != engine.EventTypeBlocked {
+		t.Fatalf("expected blocked state, got %q", snapshot.State)
+	}
+	if snapshot.Ready {
+		t.Fatalf("expected ready=false after blocked event")
+	}
+	if snapshot.Message != "waiting" {
+		t.Fatalf("expected message to be retained, got %q", snapshot.Message)
+	}
+
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeReady, Message: "ready", Timestamp: base.Add(2 * time.Second)})
+
+	snapshot = tracker.Snapshot()["api"]
+	if snapshot.State != engine.EventTypeReady {
+		t.Fatalf("expected ready state, got %q", snapshot.State)
+	}
+	if !snapshot.Ready {
+		t.Fatalf("expected ready=true after ready event")
+	}
+	if snapshot.Message != "ready" {
+		t.Fatalf("expected message to update, got %q", snapshot.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- track deployment state and engine events within the CLI context for reuse
- render the status command from runtime state instead of static metadata
- cover blocked to ready transitions in new CLI status unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e191c51c0083258ee0ae49665c35e4