### PR TITLE
Add --since filtering to logs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ orco graph [--dot]
 orco apply
 ```
 
+Use `--since` to restrict streaming to recent activity, for example `orco logs --since 10m` only emits log records from the last ten minutes.
+
 Command behavior emphasizes descriptive errors, for example: `api blocked: dependency db not Ready (timeout 60s, probe failing tcp connect)`.
 
 ## Comparison


### PR DESCRIPTION
## Summary
- add a `--since` duration flag to `orco logs` to filter log events before encoding
- document the new flag in the CLI usage documentation
- extend the logs integration coverage to assert that older events are dropped

## Testing
- go test ./internal/cli -run Logs -v

------
https://chatgpt.com/codex/tasks/task_e_68e193b802448325a2520c3de304a551