### PR TITLE
Refine down command to reuse existing deployments

### DIFF
--- a/internal/cli/down_integration_test.go
+++ b/internal/cli/down_integration_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	stdcontext "context"
 	"errors"
 	"reflect"
 	"testing"
@@ -43,6 +44,21 @@ services:
 		stackFile:    &stackPath,
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
+
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+	events := make(chan engine.Event, 64)
+	go func() {
+		for range events {
+		}
+	}()
+	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
+	if err != nil {
+		t.Fatalf("orchestrator up: %v", err)
+	}
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
 
 	cmd := newDownCmd(ctx)
 	var stdout, stderr bytes.Buffer
@@ -93,12 +109,28 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+	events := make(chan engine.Event, 64)
+	go func() {
+		for range events {
+		}
+	}()
+	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
+	if err != nil {
+		t.Fatalf("orchestrator up: %v", err)
+	}
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	rt.stopErr["api"] = errors.New("boom")
+
 	cmd := newDownCmd(ctx)
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	if err == nil {
 		t.Fatalf("expected down command to fail due to stop error")
 	}
@@ -107,5 +139,65 @@ services:
 	}
 	if !bytes.Contains(stderr.Bytes(), []byte("stop service api: boom")) {
 		t.Fatalf("expected stop error in stderr, got: %s", stderr.String())
+	}
+}
+
+func TestDownCommandDoesNotStartServices(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  db:
+    runtime: process
+    command: ["sleep", "0"]
+  api:
+    runtime: process
+    command: ["sleep", "0"]
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
+	}
+
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+	events := make(chan engine.Event, 64)
+	go func() {
+		for range events {
+		}
+	}()
+	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
+	if err != nil {
+		t.Fatalf("orchestrator up: %v", err)
+	}
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
+
+	initialStarts := rt.startOrder()
+	rt.startErr["db"] = errors.New("should not start")
+	rt.startErr["api"] = errors.New("should not start")
+
+	cmd := newDownCmd(ctx)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("down command failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if got := rt.startOrder(); !reflect.DeepEqual(got, initialStarts) {
+		t.Fatalf("down command attempted to start services: got %v want %v", got, initialStarts)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -66,9 +66,10 @@ type context struct {
 	stackFile    *string
 	orchestrator *engine.Orchestrator
 
-	mu         sync.RWMutex
-	deployment *engine.Deployment
-	tracker    *statusTracker
+	mu                  sync.RWMutex
+	deployment          *engine.Deployment
+	deploymentStackName string
+	tracker             *statusTracker
 }
 
 func (c *context) loadStack() (*cliutil.StackDocument, error) {
@@ -85,10 +86,11 @@ func (c *context) getOrchestrator() *engine.Orchestrator {
 	return c.orchestrator
 }
 
-func (c *context) setDeployment(dep *engine.Deployment) {
+func (c *context) setDeployment(dep *engine.Deployment, stackName string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.deployment = dep
+	c.deploymentStackName = stackName
 }
 
 func (c *context) clearDeployment(dep *engine.Deployment) {
@@ -96,6 +98,7 @@ func (c *context) clearDeployment(dep *engine.Deployment) {
 	defer c.mu.Unlock()
 	if c.deployment == dep {
 		c.deployment = nil
+		c.deploymentStackName = ""
 	}
 }
 
@@ -103,6 +106,12 @@ func (c *context) currentDeployment() *engine.Deployment {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.deployment
+}
+
+func (c *context) currentDeploymentInfo() (*engine.Deployment, string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.deployment, c.deploymentStackName
 }
 
 func (c *context) statusTracker() *statusTracker {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -74,7 +74,7 @@ func runStackTUI(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (
 		return depErr
 	}
 
-	ctx.setDeployment(deployment)
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
 
 	select {
 	case <-cmd.Context().Done():
@@ -128,7 +128,7 @@ func runUpNonInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDoc
 		return depErr
 	}
 
-	ctx.setDeployment(deployment)
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
 
 	fmt.Fprintln(cmd.OutOrStdout(), "All services reported ready.")
 


### PR DESCRIPTION
## Summary
- track the active deployment's stack name in the CLI context
- update `down` to stop existing services without relaunching them and report when none are running
- expand integration coverage for `down`, including a regression test that fails if services are (re)started

## Testing
- go test ./internal/cli

------
https://chatgpt.com/codex/tasks/task_e_68e1a18244e083258a627938394193bf