### PR TITLE
Retain deployment log stream for logs command

### DIFF
--- a/internal/cli/logs_integration_test.go
+++ b/internal/cli/logs_integration_test.go
@@ -42,6 +42,8 @@ services:
 		orchestrator: engine.NewOrchestrator(runtimelib.Registry{"process": rt}),
 	}
 
+	startDeployment(t, ctx)
+
 	cmd := newLogsCmd(ctx)
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
@@ -99,11 +101,20 @@ services:
 		orchestrator: engine.NewOrchestrator(runtimelib.Registry{"process": rt}),
 	}
 
+	startDeployment(t, ctx)
+
 	cmd := newLogsCmd(ctx)
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"--since", "1m"})
+	cmd.SetArgs([]string{"--since", "1m", "-f"})
+
+	cmdCtx, cancel := stdcontext.WithCancel(stdcontext.Background())
+	cmd.SetContext(cmdCtx)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("logs command failed: %v\nstderr: %s", err, stderr.String())
@@ -119,4 +130,94 @@ services:
 	if stderr.Len() != 0 {
 		t.Fatalf("expected no stderr output, got: %s", stderr.String())
 	}
+}
+
+func TestLogsCommandDoesNotRestartServices(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+	rt.logs["api"] = []runtimelib.LogEntry{{Message: "api ready", Source: runtimelib.LogSourceStdout}}
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  api:
+    runtime: process
+    command: ["sleep", "0"]
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtimelib.Registry{"process": rt}),
+	}
+
+	startDeployment(t, ctx)
+
+	before := append([]string(nil), rt.startOrder()...)
+
+	cmd := newLogsCmd(ctx)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"-f"})
+
+	cmdCtx, cancel := stdcontext.WithCancel(stdcontext.Background())
+	cmd.SetContext(cmdCtx)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("logs command failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "\"service\":\"api\"") {
+		t.Fatalf("expected api logs in output, got: %s", stdout.String())
+	}
+
+	after := rt.startOrder()
+	if len(after) != len(before) {
+		t.Fatalf("expected no additional service starts, before=%v after=%v", before, after)
+	}
+}
+
+func startDeployment(t *testing.T, ctx *context) {
+	t.Helper()
+
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
+	events := make(chan engine.Event, 256)
+	tracked, release := ctx.trackEvents(events, cap(events))
+	drained := make(chan struct{})
+	go func() {
+		for range tracked {
+		}
+		close(drained)
+	}()
+
+	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
+	if err != nil {
+		t.Fatalf("start deployment: %v", err)
+	}
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
+
+	t.Cleanup(func() {
+		stopCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), time.Second)
+		_ = deployment.Stop(stopCtx, events)
+		cancel()
+		ctx.clearDeployment(deployment)
+		release()
+		close(events)
+		<-drained
+	})
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -56,7 +56,7 @@ func runStackTUI(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (
 	}()
 
 	events := make(chan engine.Event, 256)
-	trackedEvents := ctx.trackEvents(events, cap(events))
+	trackedEvents, releaseStream := ctx.trackEvents(events, cap(events))
 
 	var forwarder sync.WaitGroup
 	forwarder.Add(1)
@@ -84,6 +84,7 @@ func runStackTUI(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (
 			cancel()
 			ctx.clearDeployment(deployment)
 		}
+		releaseStream()
 		close(events)
 		forwarder.Wait()
 		ui.CloseEvents()
@@ -117,7 +118,7 @@ func runUpInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocume
 
 func runUpNonInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (retErr error) {
 	events := make(chan engine.Event, 64)
-	trackedEvents := ctx.trackEvents(events, cap(events))
+	trackedEvents, releaseStream := ctx.trackEvents(events, cap(events))
 	var printer sync.WaitGroup
 	printer.Add(1)
 	go func() {
@@ -143,6 +144,7 @@ func runUpNonInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDoc
 			cancel()
 			ctx.clearDeployment(deployment)
 		}
+		releaseStream()
 		close(events)
 		printer.Wait()
 	}()


### PR DESCRIPTION
## Summary
- add a reusable event stream with backlog support to the shared CLI context
- register and release the shared stream when `orco up` starts or stops deployments
- consume the stored stream in `orco logs` and extend integration tests to cover the behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1bdcf93908325844fcd6826d704cb