### PR TITLE
Display event reasons in TUI status table

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -395,13 +395,7 @@ func (u *UI) applyEvent(evt engine.Event) {
 		if evt.Type == engine.EventTypeCrashed {
 			state.restarts++
 		}
-		if evt.Message != "" {
-			state.message = evt.Message
-		} else if evt.Err != nil {
-			state.message = evt.Err.Error()
-		} else {
-			state.message = ""
-		}
+		state.message = formatEventMessage(evt)
 	}
 
 	if evt.Replica+1 > state.replicas {
@@ -422,6 +416,27 @@ func (u *UI) applyEvent(evt engine.Event) {
 	u.mu.Unlock()
 
 	u.queueRefresh(updateLogs)
+}
+
+func formatEventMessage(evt engine.Event) string {
+	var parts []string
+	if evt.Message != "" {
+		parts = append(parts, evt.Message)
+	}
+	if evt.Err != nil {
+		parts = append(parts, evt.Err.Error())
+	}
+
+	message := strings.Join(parts, ": ")
+	if evt.Reason != "" {
+		if message != "" {
+			message = fmt.Sprintf("%s (%s)", message, evt.Reason)
+		} else {
+			message = evt.Reason
+		}
+	}
+
+	return message
 }
 
 func (u *UI) refreshAge() {

--- a/internal/tui/ui_message_test.go
+++ b/internal/tui/ui_message_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+func TestFormatEventMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		evt  engine.Event
+		want string
+	}{
+		{
+			name: "message only",
+			evt:  engine.Event{Message: "starting up"},
+			want: "starting up",
+		},
+		{
+			name: "error only",
+			evt:  engine.Event{Err: errors.New("failed to connect")},
+			want: "failed to connect",
+		},
+		{
+			name: "message and error",
+			evt:  engine.Event{Message: "start failed", Err: errors.New("exit status 1")},
+			want: "start failed: exit status 1",
+		},
+		{
+			name: "message and reason",
+			evt:  engine.Event{Message: "probe failed", Reason: engine.ReasonProbeUnready},
+			want: "probe failed (probe_unready)",
+		},
+		{
+			name: "error and reason",
+			evt:  engine.Event{Err: errors.New("connection refused"), Reason: engine.ReasonRestart},
+			want: "connection refused (restart)",
+		},
+		{
+			name: "reason only",
+			evt:  engine.Event{Reason: engine.ReasonRestart},
+			want: "restart",
+		},
+		{
+			name: "message, error, and reason",
+			evt:  engine.Event{Message: "crashed", Err: errors.New("signal: 9"), Reason: engine.ReasonRestart},
+			want: "crashed: signal: 9 (restart)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatEventMessage(tt.evt); got != tt.want {
+				t.Fatalf("formatEventMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- build the service table message from event message, error, and reason fields so restart/probe causes are visible
- add coverage for the message formatter to ensure punctuation and reason handling stay consistent

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1cbd059748325bf21e2e3bcbea0b0