### PR TITLE
Respect focus when handling global shortcuts

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -271,6 +271,21 @@ func (u *UI) consumeEvents(ctx context.Context) {
 }
 
 func (u *UI) handleKey(event *tcell.EventKey) *tcell.EventKey {
+	switch focused := u.app.GetFocus(); focused {
+	case nil:
+		return event
+	case u.table:
+		if u.logsFocused {
+			u.logsFocused = false
+		}
+	case u.logs:
+		if !u.logsFocused {
+			u.logsFocused = true
+		}
+	default:
+		return event
+	}
+
 	switch event.Key() {
 	case tcell.KeyEnter:
 		u.toggleFocus()
@@ -325,10 +340,12 @@ func (u *UI) showFilterPrompt() {
 			u.applyFilter(input.GetText())
 			u.pages.RemovePage(filterPageName)
 			u.app.SetFocus(u.table)
+			u.logsFocused = false
 		}).
 		AddButton("Cancel", func() {
 			u.pages.RemovePage(filterPageName)
 			u.app.SetFocus(u.table)
+			u.logsFocused = false
 		})
 
 	form.SetBorder(true).SetTitle("Filter Services")
@@ -373,6 +390,7 @@ func (u *UI) showErrorModal(message string) {
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			u.pages.RemovePage(filterPageName)
 			u.app.SetFocus(u.table)
+			u.logsFocused = false
 		})
 
 	// Ensure previous filter prompt is removed to avoid stacking pages.

--- a/internal/tui/ui_keys_test.go
+++ b/internal/tui/ui_keys_test.go
@@ -1,0 +1,87 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+func newTestUI(t *testing.T) *UI {
+	t.Helper()
+	app := tview.NewApplication()
+	table := tview.NewTable().SetFixed(1, 1).SetSelectable(true, false)
+	logs := tview.NewTextView()
+	flex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(table, 0, 3, true).
+		AddItem(logs, 0, 2, false)
+	pages := tview.NewPages().AddPage("main", flex, true, true)
+
+	ui := &UI{
+		app:        app,
+		pages:      pages,
+		table:      table,
+		logs:       logs,
+		events:     make(chan engine.Event, 1),
+		services:   make(map[string]*serviceState),
+		logsPretty: true,
+		maxLogs:    defaultLogRetention,
+		done:       make(chan struct{}),
+	}
+
+	app.SetRoot(pages, true)
+	app.SetInputCapture(ui.handleKey)
+
+	return ui
+}
+
+func TestHandleKeyRespectsOverlayFocus(t *testing.T) {
+	ui := newTestUI(t)
+	ui.app.SetFocus(ui.table)
+
+	slash := tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModNone)
+	if res := ui.handleKey(slash); res != nil {
+		t.Fatalf("expected filter shortcut to be consumed when table focused")
+	}
+
+	if _, ok := ui.app.GetFocus().(*tview.InputField); !ok {
+		t.Fatalf("expected filter input to have focus, got %T", ui.app.GetFocus())
+	}
+
+	enter := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	if res := ui.handleKey(enter); res != enter {
+		t.Fatalf("expected Enter to bypass global handler when overlay focused")
+	}
+
+	runeEvent := tcell.NewEventKey(tcell.KeyRune, 'x', tcell.ModNone)
+	if res := ui.handleKey(runeEvent); res != runeEvent {
+		t.Fatalf("expected rune to bypass global handler when overlay focused")
+	}
+
+	ui.pages.RemovePage(filterPageName)
+	ui.app.SetFocus(ui.table)
+
+	if res := ui.handleKey(runeEvent); res != runeEvent {
+		t.Fatalf("expected rune to pass through when table focused")
+	}
+	if ui.logsFocused {
+		t.Fatalf("expected logsFocused to match table focus")
+	}
+}
+
+func TestHandleKeyAllowsLogShortcuts(t *testing.T) {
+	ui := newTestUI(t)
+	ui.app.SetFocus(ui.table)
+
+	ui.toggleFocus()
+	if ui.app.GetFocus() != ui.logs {
+		t.Fatalf("expected logs to have focus after toggle")
+	}
+
+	slash := tcell.NewEventKey(tcell.KeyRune, '/', tcell.ModNone)
+	if res := ui.handleKey(slash); res != nil {
+		t.Fatalf("expected filter shortcut to be consumed when logs focused")
+	}
+}


### PR DESCRIPTION
## Summary
- gate global shortcut handling on the table/log focus and keep the tracked focus flag in sync when overlays close
- ensure the filter prompt and error modal restore table focus state when dismissed
- add regression tests that verify shortcuts are bypassed for overlay inputs while still working for the log pane

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1d5a2a84083259ff6541f2d2d84ed