### PR TITLE
Handle multi-replica orchestration and tracking

### DIFF
--- a/internal/cli/down_integration_test.go
+++ b/internal/cli/down_integration_test.go
@@ -134,10 +134,10 @@ services:
 	if err == nil {
 		t.Fatalf("expected down command to fail due to stop error")
 	}
-	if got, want := err.Error(), "stop service api: boom"; got != want {
+	if got, want := err.Error(), "stop service api replica 0: boom"; got != want {
 		t.Fatalf("unexpected error: got %q want %q", got, want)
 	}
-	if !bytes.Contains(stderr.Bytes(), []byte("stop service api: boom")) {
+	if !bytes.Contains(stderr.Bytes(), []byte("stop service api replica 0: boom")) {
 		t.Fatalf("expected stop error in stderr, got: %s", stderr.String())
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -24,11 +24,12 @@ func newStatusCmd(ctx *context) *cobra.Command {
 			snapshot := tracker.Snapshot()
 
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "SERVICE\tSTATE\tREADY\tRESTARTS\tAGE\tMESSAGE")
+			fmt.Fprintln(w, "SERVICE\tSTATE\tREADY\tREPL\tRESTARTS\tAGE\tMESSAGE")
 			for _, name := range doc.File.ServicesSorted() {
 				status, ok := snapshot[name]
 				state := formatStatusState(status.State)
 				ready := "-"
+				replicas := "-"
 				restarts := 0
 				age := "-"
 				message := "-"
@@ -48,6 +49,9 @@ func newStatusCmd(ctx *context) *cobra.Command {
 					} else {
 						ready = "No"
 					}
+					if status.Replicas > 0 {
+						replicas = fmt.Sprintf("%d", status.Replicas)
+					}
 					restarts = status.Restarts
 					if status.Message != "" {
 						message = status.Message
@@ -56,7 +60,7 @@ func newStatusCmd(ctx *context) *cobra.Command {
 					}
 					state = formatStatusState(status.State)
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n", name, state, ready, restarts, age, message)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n", name, state, ready, replicas, restarts, age, message)
 			}
 			w.Flush()
 			fmt.Fprintf(cmd.OutOrStdout(), "\nStack: %s (version %s)\n", doc.File.Stack.Name, doc.File.Version)

--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -52,14 +52,14 @@ const (
 	ReasonDependencyBlocked = "dependency_blocked"
 )
 
-func sendEvent(events chan<- Event, service string, t EventType, message string, attempt int, reason string, err error) {
+func sendEvent(events chan<- Event, service string, replica int, t EventType, message string, attempt int, reason string, err error) {
 	if events == nil {
 		return
 	}
 	events <- Event{
 		Timestamp: time.Now(),
 		Service:   service,
-		Replica:   0,
+		Replica:   replica,
 		Type:      t,
 		Message:   message,
 		Level:     "info",

--- a/internal/engine/supervisor_test.go
+++ b/internal/engine/supervisor_test.go
@@ -39,7 +39,7 @@ func TestSupervisorRestartsOnUnready(t *testing.T) {
 	}
 
 	events := make(chan Event, 32)
-	sup := newSupervisor("web", svc, rt, events)
+	sup := newSupervisor("web", 0, svc, rt, events)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 
@@ -175,7 +175,7 @@ func TestSupervisorBackoffJitter(t *testing.T) {
 
 	delayCh := make(chan time.Duration, 8)
 	var delays []time.Duration
-	sup := newSupervisor("db", svc, rt, make(chan Event, 32))
+	sup := newSupervisor("db", 0, svc, rt, make(chan Event, 32))
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error {
 		delayCh <- d
@@ -234,7 +234,7 @@ func TestSupervisorMaxRetriesEmitsFailed(t *testing.T) {
 	events := make(chan Event, 32)
 	rt := &fakeRuntime{instances: []*fakeInstance{inst1, inst2}}
 
-	sup := newSupervisor("api", svc, rt, events)
+	sup := newSupervisor("api", 0, svc, rt, events)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 
@@ -306,7 +306,7 @@ func TestSupervisorStartFailuresEmitFailedEvent(t *testing.T) {
 		startCh:   make(chan struct{}, 2),
 	}
 
-	sup := newSupervisor("api", svc, rt, events)
+	sup := newSupervisor("api", 0, svc, rt, events)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 
@@ -377,7 +377,7 @@ func TestSupervisorCancelDuringBackoffDeliversCancellation(t *testing.T) {
 		startCh:   make(chan struct{}, 1),
 	}
 
-	sup := newSupervisor("api", svc, rt, nil)
+	sup := newSupervisor("api", 0, svc, rt, nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 
 	sleepCalled := make(chan struct{})

--- a/internal/logmux/mux.go
+++ b/internal/logmux/mux.go
@@ -190,7 +190,7 @@ func synthesizeDropEvent(service string, rec dropRecord) engine.Event {
 	return engine.Event{
 		Timestamp: time.Now(),
 		Service:   service,
-		Replica:   0,
+		Replica:   -1,
 		Type:      engine.EventTypeLog,
 		Message:   fmt.Sprintf("dropped=%d", rec.count),
 		Level:     "warn",

--- a/internal/tui/ui_replica_test.go
+++ b/internal/tui/ui_replica_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+func TestUIApplyEventAggregatesReplicas(t *testing.T) {
+	ui := newTestUI(t)
+
+	base := time.Now()
+	ui.applyEventLocked(engine.Event{Service: "api", Replica: 0, Type: engine.EventTypeStarting, Timestamp: base})
+	ui.applyEventLocked(engine.Event{Service: "api", Replica: 1, Type: engine.EventTypeStarting, Timestamp: base.Add(5 * time.Millisecond)})
+
+	state := ui.services["api"]
+	if state == nil {
+		t.Fatalf("expected service state to be created")
+	}
+	if state.replicaCount != 2 {
+		t.Fatalf("expected replica count 2, got %d", state.replicaCount)
+	}
+	if state.ready {
+		t.Fatalf("expected service to be unready until replicas ready")
+	}
+
+	ui.applyEventLocked(engine.Event{Service: "api", Replica: 0, Type: engine.EventTypeReady, Message: "ready", Timestamp: base.Add(10 * time.Millisecond)})
+
+	state = ui.services["api"]
+	if state.ready {
+		t.Fatalf("expected service to remain unready until all replicas ready")
+	}
+
+	ui.applyEventLocked(engine.Event{Service: "api", Replica: 1, Type: engine.EventTypeReady, Message: "ready", Timestamp: base.Add(15 * time.Millisecond)})
+
+	state = ui.services["api"]
+	if !state.ready {
+		t.Fatalf("expected service to become ready once all replicas ready")
+	}
+
+	ui.applyEventLocked(engine.Event{Service: "api", Replica: 1, Type: engine.EventTypeCrashed, Message: "boom", Timestamp: base.Add(20 * time.Millisecond)})
+
+	state = ui.services["api"]
+	if state.ready {
+		t.Fatalf("expected service to be unready after replica crash")
+	}
+	if state.restarts != 1 {
+		t.Fatalf("expected restarts=1, got %d", state.restarts)
+	}
+	if state.state != engine.EventTypeCrashed {
+		t.Fatalf("expected crashed state, got %q", state.state)
+	}
+	if state.message == "" || !strings.Contains(state.message, "replica 1") {
+		t.Fatalf("expected message to reference replica, got %q", state.message)
+	}
+}


### PR DESCRIPTION
## Summary
- start one supervisor per replica and gate dependent services on every replica reaching the required state while tagging lifecycle events with replica IDs
- aggregate per-replica readiness/restart information in the CLI/TUI status views and expose replica counts in the CLI status output
- add regression coverage for multi-replica orchestration, status tracking, and UI aggregation behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1e621378c8325818b68be601d0fc3