### PR TITLE
Implement rolling restart orchestration for CLI

### DIFF
--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -25,7 +27,64 @@ func newRestartCmd(ctx *context) *cobra.Command {
 			if svc.Update != nil && svc.Update.Strategy != "" {
 				strategy = svc.Update.Strategy
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Planned restart for %s (strategy=%s, replicas=%d). Implementation pending.\n", svcName, strategy, svc.Replicas)
+			if strategy != "rolling" {
+				return fmt.Errorf("unsupported update strategy %q for service %s", strategy, svcName)
+			}
+
+			dep, stackName := ctx.currentDeploymentInfo()
+			if dep == nil {
+				return errors.New("no active deployment to restart")
+			}
+			if stackName != "" && stackName != doc.File.Stack.Name {
+				return fmt.Errorf("active deployment %s does not match stack %s", stackName, doc.File.Stack.Name)
+			}
+
+			service, ok := dep.Service(svcName)
+			if !ok {
+				return fmt.Errorf("service %s is not currently running", svcName)
+			}
+
+			replicas := service.Replicas()
+			if replicas < 1 {
+				replicas = 1
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Rolling restart of %s (%d replicas)\n", svcName, replicas)
+
+			tracker := ctx.statusTracker()
+
+			for i := 0; i < replicas; i++ {
+				fmt.Fprintf(cmd.OutOrStdout(), "Restarting %s replica %d/%d...\n", svcName, i+1, replicas)
+				if err := service.RestartReplica(cmd.Context(), i); err != nil {
+					return fmt.Errorf("restart %s replica %d: %w", svcName, i, err)
+				}
+
+				var status ServiceStatus
+				deadline := time.Now().Add(5 * time.Second)
+				for {
+					snapshot := tracker.Snapshot()
+					status = snapshot[svcName]
+					if status.Ready && status.ReadyReplicas >= replicas {
+						break
+					}
+					if time.Now().After(deadline) {
+						return fmt.Errorf("timed out waiting for %s readiness after restarting replica %d", svcName, i)
+					}
+					select {
+					case <-cmd.Context().Done():
+						return cmd.Context().Err()
+					case <-time.After(50 * time.Millisecond):
+					}
+				}
+
+				readyReplicas := status.ReadyReplicas
+				if readyReplicas > replicas {
+					readyReplicas = replicas
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Replica %d/%d ready (service readiness: %d/%d, Ready)\n", i+1, replicas, readyReplicas, replicas)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Completed rolling restart of %s.\n", svcName)
 			return nil
 		},
 	}

--- a/internal/cli/restart_integration_test.go
+++ b/internal/cli/restart_integration_test.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"bytes"
+	stdcontext "context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/runtime"
+)
+
+func TestRestartCommandPerReplicaSequence(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  api:
+    runtime: process
+    replicas: 3
+    command: ["sleep", "0"]
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
+	}
+
+	events := make(chan engine.Event, 128)
+	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	defer release()
+
+	done := make(chan struct{})
+	go func() {
+		for range trackedEvents {
+		}
+		close(done)
+	}()
+
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
+	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
+	if err != nil {
+		t.Fatalf("orchestrator up: %v", err)
+	}
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	t.Cleanup(func() {
+		stopCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), time.Second)
+		_ = deployment.Stop(stopCtx, events)
+		cancel()
+		close(events)
+		<-done
+	})
+
+	waitDeadline := time.Now().Add(2 * time.Second)
+	for {
+		snap := ctx.statusTracker().Snapshot()["api"]
+		if snap.Ready && snap.ReadyReplicas == 3 {
+			break
+		}
+		if time.Now().After(waitDeadline) {
+			t.Fatalf("service did not report ready before restart: %+v", snap)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cmd := newRestartCmd(ctx)
+	execCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), 5*time.Second)
+	defer cancel()
+	cmd.SetContext(execCtx)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"api"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("restart command failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	output := stdout.String()
+	expectations := []string{
+		"Rolling restart of api (3 replicas)",
+		"Restarting api replica 1/3",
+		"Replica 1/3 ready (service readiness: 3/3, Ready)",
+		"Restarting api replica 2/3",
+		"Replica 2/3 ready (service readiness: 3/3, Ready)",
+		"Restarting api replica 3/3",
+		"Replica 3/3 ready (service readiness: 3/3, Ready)",
+		"Completed rolling restart of api.",
+	}
+	for _, want := range expectations {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+		}
+	}
+
+	stops := rt.stopOrder()
+	if len(stops) != 3 {
+		t.Fatalf("expected three stop invocations, got %d", len(stops))
+	}
+
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got: %s", stderr.String())
+	}
+}
+
+func TestRestartServiceHandleSequential(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  api:
+    runtime: process
+    replicas: 3
+    command: ["sleep", "0"]
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
+	}
+
+	events := make(chan engine.Event, 128)
+	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	defer release()
+
+	done := make(chan struct{})
+	go func() {
+		for range trackedEvents {
+		}
+		close(done)
+	}()
+
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
+	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
+	if err != nil {
+		t.Fatalf("orchestrator up: %v", err)
+	}
+	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	t.Cleanup(func() {
+		stopCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), time.Second)
+		_ = deployment.Stop(stopCtx, events)
+		cancel()
+		close(events)
+		<-done
+	})
+
+	waitDeadline := time.Now().Add(2 * time.Second)
+	for {
+		snap := ctx.statusTracker().Snapshot()["api"]
+		if snap.Ready && snap.ReadyReplicas == 3 {
+			break
+		}
+		if time.Now().After(waitDeadline) {
+			t.Fatalf("service did not report ready before restart: %+v", snap)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	service, ok := deployment.Service("api")
+	if !ok {
+		t.Fatalf("expected deployment to expose service handle")
+	}
+
+	for i := 0; i < service.Replicas(); i++ {
+		stepCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), 5*time.Second)
+		if err := service.RestartReplica(stepCtx, i); err != nil {
+			cancel()
+			t.Fatalf("restart replica %d: %v", i, err)
+		}
+		cancel()
+
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			snap := ctx.statusTracker().Snapshot()["api"]
+			if snap.Ready && snap.ReadyReplicas == service.Replicas() {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("service not ready after restarting replica %d: %+v", i, snap)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement the `orco restart` command to coordinate sequential restarts while verifying readiness
- expose per-replica restart orchestration in the engine and supervisor layers with supporting tests
- extend status tracking, mocks, and add integration coverage for multi-replica rolling restarts

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1ebbed2d88325bf5ae31ecad6c569