### PR TITLE
Show replica readiness counts in CLI status output

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -44,13 +44,20 @@ func newStatusCmd(ctx *context) *cobra.Command {
 						ageDur = ageDur.Truncate(time.Second)
 						age = ageDur.String()
 					}
+					readyState := "No"
 					if status.Ready {
-						ready = "Yes"
-					} else {
-						ready = "No"
+						readyState = "Yes"
 					}
-					if status.Replicas > 0 {
-						replicas = fmt.Sprintf("%d", status.Replicas)
+					totalReplicas := status.Replicas
+					if totalReplicas > 0 {
+						readyReplicas := status.ReadyReplicas
+						if readyReplicas > totalReplicas {
+							readyReplicas = totalReplicas
+						}
+						ready = fmt.Sprintf("%s (%d/%d)", readyState, readyReplicas, totalReplicas)
+						replicas = fmt.Sprintf("%d", totalReplicas)
+					} else {
+						ready = readyState
 					}
 					restarts = status.Restarts
 					if status.Message != "" {

--- a/internal/cli/status_command_test.go
+++ b/internal/cli/status_command_test.go
@@ -63,6 +63,9 @@ services:
 	if !strings.Contains(apiLine, "Yes") {
 		t.Fatalf("expected api line to show ready=Yes, got: %s", apiLine)
 	}
+	if !strings.Contains(apiLine, "1/1") {
+		t.Fatalf("expected api line to include replica readiness, got: %s", apiLine)
+	}
 	if !strings.Contains(apiLine, "service ready") {
 		t.Fatalf("expected api ready message, got: %s", apiLine)
 	}
@@ -70,6 +73,9 @@ services:
 	dbLine := findServiceLine(output, "db")
 	if !strings.Contains(dbLine, "Ready") {
 		t.Fatalf("expected db to remain ready, got: %s", dbLine)
+	}
+	if !strings.Contains(dbLine, "1/1") {
+		t.Fatalf("expected db line to include replica readiness, got: %s", dbLine)
 	}
 }
 


### PR DESCRIPTION
## Summary
- display the ready replica ratio alongside boolean readiness in the `orco status` table
- adjust the status command integration test to assert the new readiness formatting

## Testing
- go test ./internal/cli -run TestStatusCommandReflectsBlockedAndReadyTransitions -count=1
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e27011d274832597994c03a3ec4a34