### PR TITLE
Implement apply updates with rolling restart support

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -1,23 +1,133 @@
 package cli
 
 import (
+	stdcontext "context"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func newApplyCmd(ctx *context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
-		Short: "Reconcile stack changes (planned)",
+		Short: "Reconcile stack changes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			doc, err := ctx.loadStack()
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Apply is not yet implemented. Stack %s parsed successfully.\n", doc.File.Stack.Name)
+
+			dep, stackName := ctx.currentDeploymentInfo()
+			if dep == nil {
+				return errors.New("no active deployment to apply changes to")
+			}
+			if stackName != "" && stackName != doc.File.Stack.Name {
+				return fmt.Errorf("active deployment %s does not match stack %s", stackName, doc.File.Stack.Name)
+			}
+
+			oldSpec := ctx.currentDeploymentSpec()
+			if len(oldSpec) == 0 {
+				return errors.New("no stored stack specification for active deployment")
+			}
+
+			newSpec := stack.CloneServiceMap(doc.File.Services)
+			diffs, targets, unsupported := diffStackServices(oldSpec, newSpec)
+
+			diffOutput := formatServiceDiffs(diffs)
+			fmt.Fprintln(cmd.OutOrStdout(), diffOutput)
+			if len(diffs) == 0 {
+				return nil
+			}
+
+			if len(unsupported) > 0 {
+				return fmt.Errorf("apply does not support adding or removing services: %s", strings.Join(unsupported, ", "))
+			}
+
+			if err := applyUpdates(cmd, ctx, dep, oldSpec, newSpec, targets); err != nil {
+				return err
+			}
+
+			ctx.setDeployment(dep, doc.File.Stack.Name, newSpec)
 			return nil
 		},
 	}
 	return cmd
+}
+
+func applyUpdates(cmd *cobra.Command, cliCtx *context, dep *engine.Deployment, oldSpec, newSpec map[string]*stack.Service, services []string) error {
+	tracker := cliCtx.statusTracker()
+	updated := make([]string, 0, len(services))
+
+	for _, name := range services {
+		svcSpec := newSpec[name]
+		service, ok := dep.Service(name)
+		if !ok {
+			return fmt.Errorf("service %s is not currently running", name)
+		}
+
+		replicas := service.Replicas()
+		if replicas < 1 {
+			replicas = 1
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Updating %s (%d replicas)\n", name, replicas)
+		updated = append(updated, name)
+		if err := service.Update(cmd.Context(), svcSpec); err != nil {
+			rollbackErr := rollbackUpdates(cmd.Context(), dep, oldSpec, updated)
+			if rollbackErr != nil {
+				return fmt.Errorf("update %s failed: %v (rollback error: %v)", name, err, rollbackErr)
+			}
+			return fmt.Errorf("update %s failed: %w", name, err)
+		}
+
+		status := tracker.Snapshot()[name]
+		if status.ReadyReplicas < replicas {
+			deadline := time.Now().Add(5 * time.Second)
+			for status.ReadyReplicas < replicas && time.Now().Before(deadline) {
+				select {
+				case <-cmd.Context().Done():
+					return cmd.Context().Err()
+				case <-time.After(50 * time.Millisecond):
+				}
+				status = tracker.Snapshot()[name]
+			}
+		}
+		ready := status.ReadyReplicas
+		if ready > replicas {
+			ready = replicas
+		}
+		state := "Not Ready"
+		if status.Ready {
+			state = "Ready"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Service %s ready (%d/%d replicas, %s)\n", name, ready, replicas, state)
+	}
+
+	return nil
+}
+
+func rollbackUpdates(ctx stdcontext.Context, dep *engine.Deployment, oldSpec map[string]*stack.Service, services []string) error {
+	var errs []error
+	for i := len(services) - 1; i >= 0; i-- {
+		name := services[i]
+		spec := oldSpec[name]
+		if spec == nil {
+			continue
+		}
+		service, ok := dep.Service(name)
+		if !ok {
+			errs = append(errs, fmt.Errorf("rollback %s: service no longer running", name))
+			continue
+		}
+		if err := service.Update(ctx, spec); err != nil {
+			errs = append(errs, fmt.Errorf("rollback %s: %w", name, err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/internal/cli/apply_diff.go
+++ b/internal/cli/apply_diff.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Paintersrp/orco/internal/stack"
+)
+
+type serviceDiff struct {
+	Name    string
+	Changes []string
+}
+
+func diffStackServices(oldSpec, newSpec map[string]*stack.Service) (diffs []serviceDiff, updateTargets []string, unsupported []string) {
+	if len(oldSpec) == 0 && len(newSpec) == 0 {
+		return nil, nil, nil
+	}
+	names := make(map[string]struct{}, len(oldSpec)+len(newSpec))
+	for name := range oldSpec {
+		names[name] = struct{}{}
+	}
+	for name := range newSpec {
+		names[name] = struct{}{}
+	}
+	ordered := make([]string, 0, len(names))
+	for name := range names {
+		ordered = append(ordered, name)
+	}
+	sort.Strings(ordered)
+
+	for _, name := range ordered {
+		oldSvc := oldSpec[name]
+		newSvc := newSpec[name]
+		switch {
+		case oldSvc == nil && newSvc == nil:
+			continue
+		case oldSvc == nil:
+			diffs = append(diffs, serviceDiff{Name: name, Changes: []string{"Service added."}})
+			unsupported = append(unsupported, name)
+		case newSvc == nil:
+			diffs = append(diffs, serviceDiff{Name: name, Changes: []string{"Service removed."}})
+			unsupported = append(unsupported, name)
+		default:
+			changes := diffServiceFields(oldSvc, newSvc)
+			if len(changes) == 0 {
+				continue
+			}
+			diffs = append(diffs, serviceDiff{Name: name, Changes: changes})
+			updateTargets = append(updateTargets, name)
+		}
+	}
+	return diffs, updateTargets, unsupported
+}
+
+func diffServiceFields(oldSvc, newSvc *stack.Service) []string {
+	if oldSvc == nil || newSvc == nil {
+		return nil
+	}
+	var changes []string
+	if strings.TrimSpace(oldSvc.Image) != strings.TrimSpace(newSvc.Image) {
+		changes = append(changes, fmt.Sprintf("Image: %s -> %s", valueOrPlaceholder(oldSvc.Image), valueOrPlaceholder(newSvc.Image)))
+	}
+	if !equalCommands(oldSvc.Command, newSvc.Command) {
+		changes = append(changes, fmt.Sprintf("Command: %s -> %s", formatCommand(oldSvc.Command), formatCommand(newSvc.Command)))
+	}
+	if envLines := diffEnv(oldSvc.Env, newSvc.Env); len(envLines) > 0 {
+		changes = append(changes, "Env:")
+		for _, line := range envLines {
+			changes = append(changes, "  "+line)
+		}
+	}
+	return changes
+}
+
+func equalCommands(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func formatCommand(cmd []string) string {
+	if len(cmd) == 0 {
+		return "[]"
+	}
+	quoted := make([]string, len(cmd))
+	for i, arg := range cmd {
+		quoted[i] = fmt.Sprintf("%q", arg)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
+func valueOrPlaceholder(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "<empty>"
+	}
+	return v
+}
+
+func diffEnv(oldEnv, newEnv map[string]string) []string {
+	if len(oldEnv) == 0 && len(newEnv) == 0 {
+		return nil
+	}
+	keys := make(map[string]struct{}, len(oldEnv)+len(newEnv))
+	for k := range oldEnv {
+		keys[k] = struct{}{}
+	}
+	for k := range newEnv {
+		keys[k] = struct{}{}
+	}
+	ordered := make([]string, 0, len(keys))
+	for k := range keys {
+		ordered = append(ordered, k)
+	}
+	sort.Strings(ordered)
+
+	var lines []string
+	for _, key := range ordered {
+		oldVal, oldOK := oldEnv[key]
+		newVal, newOK := newEnv[key]
+		switch {
+		case !oldOK && newOK:
+			lines = append(lines, fmt.Sprintf("+ %s=%s", key, newVal))
+		case oldOK && !newOK:
+			lines = append(lines, fmt.Sprintf("- %s", key))
+		case oldVal != newVal:
+			lines = append(lines, fmt.Sprintf("~ %s: %s -> %s", key, oldVal, newVal))
+		}
+	}
+	return lines
+}
+
+func formatServiceDiffs(diffs []serviceDiff) string {
+	if len(diffs) == 0 {
+		return "No changes detected."
+	}
+	var b strings.Builder
+	for i, diff := range diffs {
+		fmt.Fprintf(&b, "Service %s:\n", diff.Name)
+		for _, line := range diff.Changes {
+			fmt.Fprintf(&b, "  %s\n", line)
+		}
+		if i != len(diffs)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/cli/down_integration_test.go
+++ b/internal/cli/down_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Paintersrp/orco/internal/engine"
 	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func TestDownCommandStopsServicesInReverseOrder(t *testing.T) {
@@ -58,7 +59,7 @@ services:
 	if err != nil {
 		t.Fatalf("orchestrator up: %v", err)
 	}
-	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	ctx.setDeployment(deployment, doc.File.Stack.Name, stack.CloneServiceMap(doc.File.Services))
 
 	cmd := newDownCmd(ctx)
 	var stdout, stderr bytes.Buffer
@@ -122,7 +123,7 @@ services:
 	if err != nil {
 		t.Fatalf("orchestrator up: %v", err)
 	}
-	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	ctx.setDeployment(deployment, doc.File.Stack.Name, stack.CloneServiceMap(doc.File.Services))
 	rt.stopErr["api"] = errors.New("boom")
 
 	cmd := newDownCmd(ctx)
@@ -182,7 +183,7 @@ services:
 	if err != nil {
 		t.Fatalf("orchestrator up: %v", err)
 	}
-	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	ctx.setDeployment(deployment, doc.File.Stack.Name, stack.CloneServiceMap(doc.File.Services))
 
 	initialStarts := rt.startOrder()
 	rt.startErr["db"] = errors.New("should not start")

--- a/internal/cli/logs_integration_test.go
+++ b/internal/cli/logs_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Paintersrp/orco/internal/engine"
 	runtimelib "github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func TestLogsCommandStreamsStructuredOutput(t *testing.T) {
@@ -209,7 +210,7 @@ func startDeployment(t *testing.T, ctx *context) {
 	if err != nil {
 		t.Fatalf("start deployment: %v", err)
 	}
-	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	ctx.setDeployment(deployment, doc.File.Stack.Name, stack.CloneServiceMap(doc.File.Services))
 
 	t.Cleanup(func() {
 		stopCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), time.Second)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Paintersrp/orco/internal/cliutil"
 	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/stack"
 	"github.com/Paintersrp/orco/internal/tui"
 )
 
@@ -102,7 +103,7 @@ func runStackTUI(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (
 		return depErr
 	}
 
-	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	ctx.setDeployment(deployment, doc.File.Stack.Name, stack.CloneServiceMap(doc.File.Services))
 
 	select {
 	case <-cmd.Context().Done():
@@ -157,7 +158,7 @@ func runUpNonInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDoc
 		return depErr
 	}
 
-	ctx.setDeployment(deployment, doc.File.Stack.Name)
+	ctx.setDeployment(deployment, doc.File.Stack.Name, stack.CloneServiceMap(doc.File.Services))
 
 	fmt.Fprintln(cmd.OutOrStdout(), "All services reported ready.")
 

--- a/internal/stack/helpers.go
+++ b/internal/stack/helpers.go
@@ -1,0 +1,17 @@
+package stack
+
+// CloneServiceMap creates a deep copy of the provided service map.
+func CloneServiceMap(services map[string]*Service) map[string]*Service {
+	if len(services) == 0 {
+		return nil
+	}
+	out := make(map[string]*Service, len(services))
+	for name, svc := range services {
+		if svc == nil {
+			out[name] = nil
+			continue
+		}
+		out[name] = svc.Clone()
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- persist the active stack specification in CLI context and add helpers to diff new stacks
- implement the apply command to show configuration changes, roll services, and rollback on failure
- extend the engine update path plus mock runtime and add integration tests for success and rollback cases

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e27b02251c8325ae255995c5eedf8e