### PR TITLE
Improve dependency graph CLI visualization

### DIFF
--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Paintersrp/orco/internal/cliutil"
+	"github.com/Paintersrp/orco/internal/config"
+	"github.com/Paintersrp/orco/internal/engine"
 )
 
 func newGraphCmd(ctx *context) *cobra.Command {
@@ -21,24 +25,122 @@ func newGraphCmd(ctx *context) *cobra.Command {
 				fmt.Fprint(cmd.OutOrStdout(), doc.Graph.DOT())
 				return nil
 			}
+			tracker := ctx.statusTracker()
+			snapshot := tracker.Snapshot()
+
 			var b strings.Builder
-			for _, svc := range doc.Graph.Services() {
-				deps := doc.File.Services[svc].DependsOn
-				if len(deps) == 0 {
-					fmt.Fprintf(&b, "%s\n", svc)
-					continue
+			services := doc.Graph.Services()
+			for i, svc := range services {
+				if i > 0 {
+					b.WriteByte('\n')
 				}
-				fmt.Fprintf(&b, "%s -> ", svc)
-				names := make([]string, len(deps))
-				for i, dep := range deps {
-					names[i] = dep.Target
-				}
-				fmt.Fprintf(&b, "%s\n", strings.Join(names, ", "))
+				renderServiceTree(&b, doc, snapshot, svc, "", nil, true, make(map[string]bool))
 			}
+
 			fmt.Fprint(cmd.OutOrStdout(), b.String())
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&dot, "dot", false, "Render in Graphviz DOT format")
 	return cmd
+}
+
+func renderServiceTree(b *strings.Builder, doc *cliutil.StackDocument, snapshot map[string]ServiceStatus, svc string, prefix string, dep *config.DepEdge, isLast bool, visited map[string]bool) {
+	linePrefix := prefix
+	if dep != nil {
+		if isLast {
+			linePrefix += "└─ "
+		} else {
+			linePrefix += "├─ "
+		}
+	}
+
+	statusLabel, statusMessage := describeServiceStatus(snapshot, svc)
+	statusText := statusLabel
+	if statusMessage != "" {
+		statusText = fmt.Sprintf("%s: %s", statusLabel, statusMessage)
+	}
+
+	annotation := ""
+	if dep != nil {
+		annotation = formatDependencyAnnotation(*dep)
+	}
+
+	fmt.Fprintf(b, "%s%s%s [%s]\n", linePrefix, svc, annotation, statusText)
+
+	if visited[svc] {
+		return
+	}
+	visited[svc] = true
+	defer delete(visited, svc)
+
+	serviceSpec, ok := doc.File.Services[svc]
+	if !ok || serviceSpec == nil {
+		return
+	}
+
+	deps := serviceSpec.DependsOn
+	if len(deps) == 0 {
+		return
+	}
+
+	nextPrefix := prefix
+	if dep != nil {
+		if isLast {
+			nextPrefix += "   "
+		} else {
+			nextPrefix += "│  "
+		}
+	}
+
+	for i, child := range deps {
+		child := child
+		renderServiceTree(b, doc, snapshot, child.Target, nextPrefix, &child, i == len(deps)-1, visited)
+	}
+}
+
+func describeServiceStatus(snapshot map[string]ServiceStatus, name string) (string, string) {
+	status, ok := snapshot[name]
+	if !ok {
+		return "Pending", ""
+	}
+	if status.Ready {
+		return "Ready", ""
+	}
+	switch status.State {
+	case engine.EventTypeBlocked:
+		message := status.Message
+		if message == "" {
+			message = "blocked"
+		}
+		return "Blocked", message
+	case engine.EventTypeFailed, engine.EventTypeCrashed, engine.EventTypeError:
+		message := status.Message
+		if message == "" {
+			message = "failure"
+		}
+		return "Failed", message
+	default:
+		label := formatStatusState(status.State)
+		message := ""
+		if status.Message != "" {
+			message = status.Message
+		}
+		if label == "-" {
+			label = "Pending"
+		}
+		return label, message
+	}
+}
+
+func formatDependencyAnnotation(dep config.DepEdge) string {
+	require := dep.Require
+	if require == "" {
+		require = "ready"
+	}
+	parts := []string{fmt.Sprintf("require=%s", require)}
+	if dep.Timeout.IsSet() {
+		parts = append(parts, fmt.Sprintf("timeout=%s", dep.Timeout.Duration))
+	}
+	return fmt.Sprintf(" (%s)", strings.Join(parts, ", "))
 }

--- a/internal/cli/graph_command_test.go
+++ b/internal/cli/graph_command_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"bytes"
+	stdcontext "context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+func TestGraphCommandRendersTreeWithStatusesAndAnnotations(t *testing.T) {
+	t.Parallel()
+
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  api:
+    runtime: process
+    command: ["sleep", "1"]
+    dependsOn:
+      - target: db
+      - target: cache
+        require: started
+        timeout: 15s
+  worker:
+    runtime: process
+    command: ["sleep", "1"]
+    dependsOn:
+      - target: db
+        require: exists
+  db:
+    runtime: process
+    command: ["sleep", "1"]
+    dependsOn:
+      - target: storage
+        require: exists
+  storage:
+    runtime: process
+    command: ["sleep", "1"]
+  cache:
+    runtime: process
+    command: ["sleep", "1"]
+    dependsOn:
+      - target: redis
+        require: ready
+  redis:
+    runtime: process
+    command: ["sleep", "1"]
+`)
+
+	ctx := &context{stackFile: &stackPath}
+	tracker := ctx.statusTracker()
+
+	base := time.Now()
+	tracker.Apply(engine.Event{Service: "storage", Type: engine.EventTypeReady, Timestamp: base})
+	tracker.Apply(engine.Event{Service: "db", Type: engine.EventTypeReady, Timestamp: base.Add(1 * time.Second)})
+	tracker.Apply(engine.Event{Service: "redis", Type: engine.EventTypeReady, Timestamp: base.Add(2 * time.Second)})
+	tracker.Apply(engine.Event{Service: "worker", Type: engine.EventTypeReady, Timestamp: base.Add(3 * time.Second)})
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeReady, Timestamp: base.Add(4 * time.Second)})
+	tracker.Apply(engine.Event{Service: "cache", Type: engine.EventTypeBlocked, Message: "waiting for redis", Replica: -1, Timestamp: base.Add(5 * time.Second)})
+
+	cmd := newGraphCmd(ctx)
+	cmd.SetContext(stdcontext.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("graph command failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	output := stdout.String()
+
+	expectations := []string{
+		"api [Ready]",
+		"├─ db (require=ready) [Ready]",
+		"│  └─ storage (require=exists) [Ready]",
+		"└─ cache (require=started, timeout=15s) [Blocked: waiting for redis]",
+		"   └─ redis (require=ready) [Ready]",
+		"worker [Ready]",
+		"└─ db (require=exists) [Ready]",
+	}
+
+	for _, expected := range expectations {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected output to contain %q, got:\n%s", expected, output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- render the graph command as a dependency tree with status, require mode, and timeout annotations
- derive node readiness/blocked/failed states from the status tracker snapshot for CLI output
- add coverage verifying branched trees, mixed require modes, and blocked service messaging

## Testing
- `go test ./internal/cli -run TestGraphCommandRendersTreeWithStatusesAndAnnotations -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68e2994a9dcc83258e569dd2c96c2f02