### PR TITLE
Enhance graph DOT output with statuses

### DIFF
--- a/internal/engine/dag_test.go
+++ b/internal/engine/dag_test.go
@@ -1,6 +1,12 @@
 package engine
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/Paintersrp/orco/internal/config"
+	"github.com/Paintersrp/orco/internal/stack"
+)
 
 func TestBuildGraphNilStackFile(t *testing.T) {
 	t.Parallel()
@@ -11,5 +17,57 @@ func TestBuildGraphNilStackFile(t *testing.T) {
 	}
 	if err != errNilStackFile {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGraphDOTIncludesStatusStylingAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	doc := &stack.StackFile{
+		Services: map[string]*stack.Service{
+			"api": {
+				DependsOn: []config.DepEdge{{Target: "db"}},
+			},
+			"db": {
+				DependsOn: []config.DepEdge{{Target: "storage", Require: "started"}},
+			},
+			"storage": {},
+		},
+	}
+
+	graph, err := BuildGraph(doc)
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+
+	statuses := map[string]GraphServiceStatus{
+		"api":     {State: EventTypeReady, Ready: true},
+		"db":      {State: EventTypeBlocked, Message: "blocked waiting for storage (started)"},
+		"storage": {State: EventTypeFailed, Message: "probe failed"},
+	}
+
+	deps := map[string]map[string]DependencyMetadata{
+		"api": {
+			"db": {Require: "ready"},
+		},
+		"db": {
+			"storage": {Require: "started", BlockingReason: "blocked waiting for storage (started)"},
+		},
+	}
+
+	dot := graph.DOT(statuses, deps)
+
+	expectations := []string{
+		"\"api\" [label=\"api\\nReady\" style=\"filled\" fillcolor=\"#c6f6d5\"];",
+		"\"db\" [label=\"db\\nBlocked\\nblocked waiting for storage (started)\" style=\"filled\" fillcolor=\"#fefcbf\"];",
+		"\"storage\" [label=\"storage\\nFailed\\nprobe failed\" style=\"filled\" fillcolor=\"#fed7d7\"];",
+		"\"api\" -> \"db\" [label=\"require=ready\"];",
+		"\"db\" -> \"storage\" [label=\"require=started\\nblocked waiting for storage (started)\"];",
+	}
+
+	for _, expected := range expectations {
+		if !strings.Contains(dot, expected) {
+			t.Fatalf("expected DOT output to contain %q, got:\n%s", expected, dot)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- extend the engine graph DOT renderer to accept service statuses and dependency metadata, applying status-aware labels and colors
- update the graph CLI command to feed status snapshots and blocking reasons into DOT generation
- add engine and CLI tests that assert DOT output includes the expected styling and edge annotations for ready and blocked services

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2a1bca9dc8325b115ef521f408873