### PR TITLE
Mask secret placeholders in CLI status and logs

### DIFF
--- a/internal/cli/status_tracker.go
+++ b/internal/cli/status_tracker.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Paintersrp/orco/internal/cliutil"
 	"github.com/Paintersrp/orco/internal/engine"
 )
 
@@ -102,7 +103,7 @@ func (t *statusTracker) Apply(evt engine.Event) {
 		if evt.Replica >= 0 && message == "" {
 			message = fmt.Sprintf("replica %d", evt.Replica)
 		}
-		state.message = message
+		state.message = cliutil.RedactSecrets(message)
 	}
 
 	totalRestarts := 0

--- a/internal/cliutil/logfmt.go
+++ b/internal/cliutil/logfmt.go
@@ -41,7 +41,7 @@ func NewLogRecord(event engine.Event) LogRecord {
 		Service:   event.Service,
 		Replica:   event.Replica,
 		Level:     level,
-		Message:   event.Message,
+		Message:   RedactSecrets(event.Message),
 		Source:    source,
 	}
 }

--- a/internal/cliutil/redact.go
+++ b/internal/cliutil/redact.go
@@ -1,0 +1,50 @@
+package cliutil
+
+import (
+	"regexp"
+	"strings"
+)
+
+const redactedPlaceholder = "[redacted]"
+
+var (
+	templateVarPattern = regexp.MustCompile(`\$\{[^}]+\}`)
+	secretKeyPattern   = regexp.MustCompile(`(?i)\b(` + strings.Join(secretKeys(), "|") + `)\b(\s*[:=]\s*)(["']?)([^"'\s]+)(["']?)`)
+)
+
+func secretKeys() []string {
+	keys := []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AZURE_CLIENT_SECRET",
+		"GCP_SERVICE_ACCOUNT_KEY",
+		"DATABASE_PASSWORD",
+		"DB_PASSWORD",
+		"POSTGRES_PASSWORD",
+		"REDIS_PASSWORD",
+		"API_KEY",
+		"ACCESS_TOKEN",
+		"REFRESH_TOKEN",
+		"CLIENT_SECRET",
+	}
+	escaped := make([]string, len(keys))
+	for i, key := range keys {
+		escaped[i] = regexp.QuoteMeta(key)
+	}
+	return escaped
+}
+
+// RedactSecrets masks common secret placeholders and sensitive key values from the
+// supplied string. It replaces ${VAR} style template references and known secret
+// key assignments with a generic [redacted] marker to avoid leaking secrets in
+// user-facing output.
+func RedactSecrets(message string) string {
+	if message == "" {
+		return message
+	}
+	redacted := templateVarPattern.ReplaceAllStringFunc(message, func(match string) string {
+		return "${" + redactedPlaceholder + "}"
+	})
+	return secretKeyPattern.ReplaceAllString(redacted, "$1$2$3"+redactedPlaceholder+"$5")
+}


### PR DESCRIPTION
## Summary
- add a cliutil.RedactSecrets helper to mask ${VAR} placeholders and common secret key assignments
- apply redaction to service status messages and JSON log records
- extend cli and cliutil tests to cover secret redaction behavior

## Testing
- go test ./internal/cliutil -run Test
- go test ./internal/cli -run StatusTracker

------
https://chatgpt.com/codex/tasks/task_e_68e2ad828e6c8325a21c0a592ee5a94a