### PR TITLE
Handle single-quoted env values in loader

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -133,8 +133,8 @@ func loadEnvFile(path string) (map[string]string, error) {
 			return nil, fmt.Errorf("load env file %q: invalid key on line %d", path, lineNo)
 		}
 		value := strings.TrimSpace(raw[sep+1:])
-		if strings.HasPrefix(value, "\"") || strings.HasPrefix(value, "'") {
-			if len(value) < 2 || value[len(value)-1] != value[0] {
+		if strings.HasPrefix(value, "\"") {
+			if len(value) < 2 || value[len(value)-1] != '"' {
 				return nil, fmt.Errorf("load env file %q: unmatched quote on line %d", path, lineNo)
 			}
 			unquoted, err := strconv.Unquote(value)
@@ -142,6 +142,11 @@ func loadEnvFile(path string) (map[string]string, error) {
 				return nil, fmt.Errorf("load env file %q: parse value for %s on line %d: %w", path, key, lineNo, err)
 			}
 			value = unquoted
+		} else if strings.HasPrefix(value, "'") {
+			if len(value) < 2 || value[len(value)-1] != '\'' {
+				return nil, fmt.Errorf("load env file %q: unmatched quote on line %d", path, lineNo)
+			}
+			value = value[1 : len(value)-1]
 		} else if comment := strings.IndexRune(value, '#'); comment >= 0 {
 			value = strings.TrimSpace(value[:comment])
 		}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -451,6 +451,31 @@ services:
 	}
 }
 
+func TestLoadEnvFileSingleQuotedValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vars.env")
+	contents := strings.Join([]string{
+		"SINGLE='value with spaces'",
+		"HASHED='value # with hash'",
+		"# comment line should be ignored",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	values, err := loadEnvFile(path)
+	if err != nil {
+		t.Fatalf("loadEnvFile returned error: %v", err)
+	}
+
+	if got, want := values["SINGLE"], "value with spaces"; got != want {
+		t.Fatalf("single-quoted value mismatch: got %q want %q", got, want)
+	}
+	if got, want := values["HASHED"], "value # with hash"; got != want {
+		t.Fatalf("single-quoted hash value mismatch: got %q want %q", got, want)
+	}
+}
+
 func equalIntSlices(a, b []int) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary
- strip single-quoted values manually when loading env files while preserving double-quote support
- add a regression test covering single-quoted env entries with spaces and hash characters

## Testing
- go test ./... *(fails: TestMuxEmitsDropMetaEvents)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b9e14c908325bb68b16bebbcb57c