### PR TITLE
Redact secrets in up CLI event output

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -189,15 +189,18 @@ func printEvents(stdout, stderr io.Writer, events <-chan engine.Event) {
 		case engine.EventTypeLog:
 			cliutil.EncodeLogEvent(encoder, stderr, event)
 		case engine.EventTypeError:
+			message := cliutil.RedactSecrets(event.Message)
 			if event.Err != nil {
-				fmt.Fprintf(stderr, "error: %s %s: %v\n", event.Service, event.Message, event.Err)
+				errMsg := cliutil.RedactSecrets(event.Err.Error())
+				fmt.Fprintf(stderr, "error: %s %s: %s\n", event.Service, message, errMsg)
 			} else {
-				fmt.Fprintf(stderr, "error: %s %s\n", event.Service, event.Message)
+				fmt.Fprintf(stderr, "error: %s %s\n", event.Service, message)
 			}
 		default:
 			label := formatEventType(event.Type)
 			if event.Message != "" {
-				fmt.Fprintf(stdout, "%s %s: %s\n", label, event.Service, event.Message)
+				message := cliutil.RedactSecrets(event.Message)
+				fmt.Fprintf(stdout, "%s %s: %s\n", label, event.Service, message)
 			} else {
 				fmt.Fprintf(stdout, "%s %s\n", label, event.Service)
 			}


### PR DESCRIPTION
## Summary
- redact event messages and error details in `printEvents` so CLI output no longer exposes secrets

## Testing
- `go test ./...` *(interrupted after prolonged dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cd61bfd8832593a76ca0b19ace96