### PR TITLE
Add status history tracking and CLI flag

### DIFF
--- a/internal/cli/status_tracker.go
+++ b/internal/cli/status_tracker.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -9,6 +12,61 @@ import (
 	"github.com/Paintersrp/orco/internal/cliutil"
 	"github.com/Paintersrp/orco/internal/engine"
 )
+
+// StatusTrackerOption configures a status tracker.
+type StatusTrackerOption func(*statusTrackerConfig)
+
+type statusTrackerConfig struct {
+	historySize    int
+	journalEnabled bool
+	journalPath    string
+}
+
+func defaultStatusTrackerConfig() statusTrackerConfig {
+	return statusTrackerConfig{
+		historySize: 20,
+	}
+}
+
+// WithHistorySize sets the number of transitions retained per service. Values
+// less than or equal to zero disable in-memory history tracking.
+func WithHistorySize(size int) StatusTrackerOption {
+	return func(cfg *statusTrackerConfig) {
+		if size <= 0 {
+			cfg.historySize = 0
+			return
+		}
+		cfg.historySize = size
+	}
+}
+
+// WithJournalEnabled toggles persistence of transitions to disk.
+func WithJournalEnabled(enabled bool) StatusTrackerOption {
+	return func(cfg *statusTrackerConfig) {
+		cfg.journalEnabled = enabled
+	}
+}
+
+// WithJournalPath overrides the path used to persist the journal when
+// journaling is enabled. When unset, a default path under the user's home
+// directory is used.
+func WithJournalPath(path string) StatusTrackerOption {
+	return func(cfg *statusTrackerConfig) {
+		cfg.journalPath = path
+	}
+}
+
+func (cfg *statusTrackerConfig) journalFilePath() string {
+	if cfg.journalPath != "" {
+		return cfg.journalPath
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".orco", "status_journal.jsonl")
+}
 
 // serviceStatus captures runtime state for a service observed via events.
 type serviceStatus struct {
@@ -23,6 +81,11 @@ type serviceStatus struct {
 	replicaCount  int
 	replicas      map[int]*replicaStatus
 	readyReplicas int
+
+	history         []ServiceTransition
+	historyCapacity int
+	historyIndex    int
+	historyCount    int
 }
 
 type replicaStatus struct {
@@ -35,10 +98,26 @@ type replicaStatus struct {
 type statusTracker struct {
 	mu       sync.RWMutex
 	services map[string]*serviceStatus
+	cfg      statusTrackerConfig
 }
 
-func newStatusTracker() *statusTracker {
-	return &statusTracker{services: make(map[string]*serviceStatus)}
+func newStatusTracker(opts ...StatusTrackerOption) *statusTracker {
+	cfg := defaultStatusTrackerConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	return &statusTracker{services: make(map[string]*serviceStatus), cfg: cfg}
+}
+
+// ServiceTransition captures a single lifecycle transition for a service.
+type ServiceTransition struct {
+	Timestamp time.Time
+	Type      engine.EventType
+	Reason    string
+	Message   string
 }
 
 // Apply updates the tracker based on the supplied event.
@@ -52,7 +131,7 @@ func (t *statusTracker) Apply(evt engine.Event) {
 
 	state := t.services[evt.Service]
 	if state == nil {
-		state = &serviceStatus{name: evt.Service, firstSeen: evt.Timestamp, replicas: make(map[int]*replicaStatus)}
+		state = newServiceStatus(evt.Service, evt.Timestamp, t.cfg.historySize)
 		t.services[evt.Service] = state
 	}
 	if state.replicas == nil {
@@ -91,19 +170,9 @@ func (t *statusTracker) Apply(evt engine.Event) {
 
 	if evt.Type != engine.EventTypeLog {
 		state.state = evt.Type
-		message := ""
-		if evt.Message != "" {
-			message = evt.Message
-		} else if evt.Err != nil {
-			message = evt.Err.Error()
-		}
-		if evt.Replica >= 0 && message != "" {
-			message = fmt.Sprintf("replica %d: %s", evt.Replica, message)
-		}
-		if evt.Replica >= 0 && message == "" {
-			message = fmt.Sprintf("replica %d", evt.Replica)
-		}
-		state.message = cliutil.RedactSecrets(message)
+		message := formatEventMessage(evt)
+		state.message = message
+		t.recordTransition(evt, state, message)
 	}
 
 	totalRestarts := 0
@@ -129,6 +198,83 @@ func (t *statusTracker) Apply(evt engine.Event) {
 	if state.state == engine.EventTypeReady && !state.ready {
 		state.state = engine.EventTypeStarting
 	}
+}
+
+func formatEventMessage(evt engine.Event) string {
+	message := ""
+	if evt.Message != "" {
+		message = evt.Message
+	} else if evt.Err != nil {
+		message = evt.Err.Error()
+	}
+	if evt.Replica >= 0 && message != "" {
+		message = fmt.Sprintf("replica %d: %s", evt.Replica, message)
+	}
+	if evt.Replica >= 0 && message == "" {
+		message = fmt.Sprintf("replica %d", evt.Replica)
+	}
+	return cliutil.RedactSecrets(message)
+}
+
+func newServiceStatus(name string, ts time.Time, historySize int) *serviceStatus {
+	status := &serviceStatus{
+		name:         name,
+		firstSeen:    ts,
+		replicas:     make(map[int]*replicaStatus),
+		historyIndex: 0,
+	}
+	if historySize > 0 {
+		status.historyCapacity = historySize
+		status.history = make([]ServiceTransition, historySize)
+	}
+	return status
+}
+
+func (t *statusTracker) recordTransition(evt engine.Event, state *serviceStatus, message string) {
+	if state.historyCapacity > 0 {
+		entry := ServiceTransition{
+			Timestamp: evt.Timestamp,
+			Type:      evt.Type,
+			Reason:    evt.Reason,
+			Message:   message,
+		}
+		state.history[state.historyIndex] = entry
+		state.historyIndex = (state.historyIndex + 1) % state.historyCapacity
+		if state.historyCount < state.historyCapacity {
+			state.historyCount++
+		}
+	}
+
+	if !t.cfg.journalEnabled {
+		return
+	}
+	path := t.cfg.journalFilePath()
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	payload := map[string]any{
+		"timestamp": evt.Timestamp,
+		"service":   evt.Service,
+		"replica":   evt.Replica,
+		"type":      evt.Type,
+		"reason":    evt.Reason,
+		"message":   message,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+	_, _ = f.Write(data)
 }
 
 // ServiceStatus captures a snapshot of a service state for presentation.
@@ -164,6 +310,38 @@ func (t *statusTracker) Snapshot() map[string]ServiceStatus {
 		}
 	}
 	return snapshot
+}
+
+// History returns up to the last n transitions observed for a service in
+// chronological order. When the service has fewer stored transitions, all of
+// them are returned.
+func (t *statusTracker) History(service string, n int) []ServiceTransition {
+	if n <= 0 {
+		return nil
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	state, ok := t.services[service]
+	if !ok || state.historyCount == 0 {
+		return nil
+	}
+
+	if n > state.historyCount {
+		n = state.historyCount
+	}
+
+	result := make([]ServiceTransition, n)
+	start := state.historyIndex - n
+	if start < 0 {
+		start += state.historyCapacity
+	}
+	for i := 0; i < n; i++ {
+		idx := (start + i) % state.historyCapacity
+		result[i] = state.history[idx]
+	}
+	return result
 }
 
 // Names returns the list of known services sorted alphabetically. Useful for tests.

--- a/internal/cli/status_tracker_test.go
+++ b/internal/cli/status_tracker_test.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -134,5 +138,111 @@ func TestStatusTrackerRedactsSecretsInMessages(t *testing.T) {
 	}
 	if !strings.Contains(snap.Message, "AWS_SECRET_ACCESS_KEY=[redacted]") {
 		t.Fatalf("expected known secret key redacted, got %q", snap.Message)
+	}
+}
+
+func TestStatusTrackerHistoryRingBuffer(t *testing.T) {
+	t.Parallel()
+
+	tracker := newStatusTracker(WithHistorySize(3))
+	base := time.Now().Add(-5 * time.Minute)
+	types := []engine.EventType{
+		engine.EventTypeStarting,
+		engine.EventTypeReady,
+		engine.EventTypeUnready,
+		engine.EventTypeStopping,
+		engine.EventTypeFailed,
+	}
+	reasons := []string{
+		engine.ReasonInitialStart,
+		engine.ReasonProbeReady,
+		engine.ReasonProbeUnready,
+		engine.ReasonSupervisorStop,
+		engine.ReasonStartFailure,
+	}
+	for i := 0; i < len(types); i++ {
+		tracker.Apply(engine.Event{
+			Service:   "api",
+			Replica:   -1,
+			Type:      types[i],
+			Message:   fmt.Sprintf("phase-%d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Reason:    reasons[i],
+		})
+	}
+
+	history := tracker.History("api", 4)
+	if len(history) != 3 {
+		t.Fatalf("expected 3 history entries due to ring buffer, got %d", len(history))
+	}
+	for idx, want := range []int{2, 3, 4} {
+		if history[idx].Type != types[want] {
+			t.Fatalf("unexpected event type at %d: got %s want %s", idx, history[idx].Type, types[want])
+		}
+		if history[idx].Reason != reasons[want] {
+			t.Fatalf("unexpected reason at %d: got %s want %s", idx, history[idx].Reason, reasons[want])
+		}
+		if !strings.Contains(history[idx].Message, fmt.Sprintf("phase-%d", want)) {
+			t.Fatalf("expected message for phase %d, got %q", want, history[idx].Message)
+		}
+	}
+
+	trimmed := tracker.History("api", 2)
+	if len(trimmed) != 2 {
+		t.Fatalf("expected trimmed history length 2, got %d", len(trimmed))
+	}
+	if trimmed[0].Type != types[3] || trimmed[1].Type != types[4] {
+		t.Fatalf("unexpected trimmed order: %+v", trimmed)
+	}
+}
+
+func TestStatusTrackerJournalOptIn(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	journalPath := filepath.Join(dir, "journal.jsonl")
+
+	tracker := newStatusTracker(WithHistorySize(2), WithJournalEnabled(true), WithJournalPath(journalPath))
+	base := time.Now().Add(-time.Minute)
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeStarting, Message: "boot", Timestamp: base, Reason: engine.ReasonInitialStart})
+	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeReady, Message: "ready", Timestamp: base.Add(5 * time.Second), Reason: engine.ReasonProbeReady})
+
+	data, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatalf("expected journal to be written: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected two journal lines, got %d", len(lines))
+	}
+	type entry struct {
+		Timestamp time.Time        `json:"timestamp"`
+		Service   string           `json:"service"`
+		Replica   int              `json:"replica"`
+		Type      engine.EventType `json:"type"`
+		Reason    string           `json:"reason"`
+		Message   string           `json:"message"`
+	}
+	history := tracker.History("api", 2)
+	for i, line := range lines {
+		var e entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("failed to parse journal line %d: %v", i, err)
+		}
+		if e.Service != "api" {
+			t.Fatalf("unexpected service in journal: %s", e.Service)
+		}
+		if e.Message == "" {
+			t.Fatalf("expected message in journal entry %d", i)
+		}
+		if e.Type != history[i].Type {
+			t.Fatalf("expected journal types to match history: %s vs %s", e.Type, history[i].Type)
+		}
+	}
+
+	trackerNoJournal := newStatusTracker(WithJournalPath(filepath.Join(dir, "disabled.jsonl")))
+	trackerNoJournal.Apply(engine.Event{Service: "api", Type: engine.EventTypeFailed, Message: "fail", Timestamp: base})
+	if _, err := os.Stat(filepath.Join(dir, "disabled.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("expected journal file to remain absent when not enabled, err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add configurable history tracking and optional journaling to the status tracker
- expose service transition history via the `status` command with a new `--history` flag
- cover history storage, journaling opt-in, and CLI formatting with new tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2df8e880c83258748910615e006b1