### PR TITLE
Add log-based readiness probing and hook runtime log streams

### DIFF
--- a/internal/probe/log.go
+++ b/internal/probe/log.go
@@ -1,0 +1,96 @@
+package probe
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Paintersrp/orco/internal/stack"
+)
+
+type logProber struct {
+	pattern *regexp.Regexp
+	sources map[string]struct{}
+	levels  map[string]struct{}
+
+	matched atomic.Bool
+	notify  chan struct{}
+	once    sync.Once
+}
+
+func newLogProber(spec *stack.LogProbe) (Prober, error) {
+	pattern, err := regexp.Compile(spec.Pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	sources := make(map[string]struct{}, len(spec.Sources))
+	for _, src := range spec.Sources {
+		lower := strings.ToLower(strings.TrimSpace(src))
+		if lower == "" {
+			continue
+		}
+		sources[lower] = struct{}{}
+	}
+
+	levels := make(map[string]struct{}, len(spec.Levels))
+	for _, lvl := range spec.Levels {
+		lower := strings.ToLower(strings.TrimSpace(lvl))
+		if lower == "" {
+			continue
+		}
+		levels[lower] = struct{}{}
+	}
+
+	return &logProber{
+		pattern: pattern,
+		sources: sources,
+		levels:  levels,
+		notify:  make(chan struct{}),
+	}, nil
+}
+
+func (p *logProber) Probe(ctx context.Context) error {
+	if p.matched.Load() {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.notify:
+		return nil
+	}
+}
+
+func (p *logProber) ObserveLog(entry LogEntry) {
+	if p.matched.Load() {
+		return
+	}
+	if len(p.sources) > 0 {
+		if _, ok := p.sources[strings.ToLower(entry.Source)]; !ok {
+			return
+		}
+	}
+	if len(p.levels) > 0 {
+		if _, ok := p.levels[strings.ToLower(entry.Level)]; !ok {
+			return
+		}
+	}
+	if !p.pattern.MatchString(entry.Message) {
+		return
+	}
+	if p.matched.CompareAndSwap(false, true) {
+		p.once.Do(func() { close(p.notify) })
+	}
+}
+
+func (p *logProber) Ready() bool {
+	return p.matched.Load()
+}
+
+var _ Prober = (*logProber)(nil)
+var _ LogObserver = (*logProber)(nil)
+var _ readyReporter = (*logProber)(nil)


### PR DESCRIPTION
## Summary
- add a log-driven prober and extend probe construction to support multi-probe OR expressions
- feed process and Docker runtime log streams into log-aware probes so readiness can trip without HTTP
- exercise log readiness and HTTP/log combinations in unit and runtime integration tests

## Testing
- GOTOOLCHAIN=local go test ./internal/probe
- GOTOOLCHAIN=local go test ./internal/runtime/process

------
https://chatgpt.com/codex/tasks/task_e_68e2eb3ee3f48325b7b9a26e971083ab