### PR TITLE
Add canary promotion flow and manual trigger support

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -125,9 +125,10 @@ type LogProbeSpec struct {
 
 // UpdateStrategy controls rolling update behaviour.
 type UpdateStrategy struct {
-	Strategy       string `yaml:"strategy"`
-	MaxUnavailable int    `yaml:"maxUnavailable"`
-	MaxSurge       int    `yaml:"maxSurge"`
+	Strategy       string   `yaml:"strategy"`
+	MaxUnavailable int      `yaml:"maxUnavailable"`
+	MaxSurge       int      `yaml:"maxSurge"`
+	PromoteAfter   Duration `yaml:"promoteAfter"`
 }
 
 // RestartPolicy defines restart behaviour for a service.
@@ -425,6 +426,7 @@ func (s *ServiceSpec) Clone() *ServiceSpec {
 			Strategy:       s.Update.Strategy,
 			MaxUnavailable: s.Update.MaxUnavailable,
 			MaxSurge:       s.Update.MaxSurge,
+			PromoteAfter:   s.Update.PromoteAfter,
 		}
 	}
 	if s.RestartPolicy != nil {

--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -21,6 +21,9 @@ const (
 	EventTypeCrashed  EventType = "crashed"
 	EventTypeFailed   EventType = "failed"
 	EventTypeBlocked  EventType = "blocked"
+	EventTypeCanary   EventType = "canary"
+	EventTypePromoted EventType = "promoted"
+	EventTypeAborted  EventType = "aborted"
 )
 
 // Event represents a single lifecycle or log notification.
@@ -50,6 +53,9 @@ const (
 	ReasonStopFailed        = "stop_failed"
 	ReasonShutdown          = "shutdown"
 	ReasonDependencyBlocked = "dependency_blocked"
+	ReasonCanary            = "canary"
+	ReasonPromoted          = "promoted"
+	ReasonAborted           = "aborted"
 )
 
 func sendEvent(events chan<- Event, service string, replica int, t EventType, message string, attempt int, reason string, err error) {


### PR DESCRIPTION
## Summary
- add a promoteAfter duration to update strategies so canary promotions can be timed
- refactor the orchestrator to emit canary/promoted/aborted events, manage promotion state, and expose promotion helpers
- update the CLI apply path to drive promotions and expand orchestrator tests for manual, timed, and failure cases

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2f2bc25e0832585130a2288e024e4