### PR TITLE
Support stack resource hints for CPU and memory limits

### DIFF
--- a/examples/canary-stack.yaml
+++ b/examples/canary-stack.yaml
@@ -16,6 +16,8 @@ services:
     command: ["sleep", "5"]
     env:
       VERSION: v1
+    resources:
+      cpu: "1.5"
     update:
       strategy: canary
       promoteAfter: 30s
@@ -28,3 +30,5 @@ services:
     command: ["sleep", "2"]
     env:
       API_URL: http://localhost:8080
+    resources:
+      memory: 64Mi

--- a/examples/demo-stack.yaml
+++ b/examples/demo-stack.yaml
@@ -24,6 +24,8 @@ services:
     env:
       POSTGRES_PASSWORD: example
     ports: ["5432:5432"]
+    resources:
+      memory: 1Gi
     health:
       http:
         url: http://localhost:5432/healthz
@@ -52,6 +54,10 @@ services:
       expression: http || log
     ports: ["8080:8080"]
     replicas: 2
+    resources:
+      cpu: "750m"
+      memory: 512Mi
+      memoryReservation: 256Mi
     restartPolicy:
       maxRetries: 10
       backoff:

--- a/internal/engine/supervisor.go
+++ b/internal/engine/supervisor.go
@@ -154,6 +154,9 @@ func buildStartSpec(name string, replica int, svc *stack.Service) runtime.StartS
 	}
 	spec.Workdir = svc.ResolvedWorkdir
 	spec.Health = svc.Health
+	if svc.Resources != nil {
+		spec.Resources = svc.Resources.Clone()
+	}
 	spec.Service = svc.Clone()
 	return spec
 }

--- a/internal/resources/parse.go
+++ b/internal/resources/parse.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	units "github.com/docker/go-units"
+)
+
+const NanoCPUs = 1_000_000_000
+
+// ParseCPU converts a textual CPU quantity into Docker nanocpu units.
+// Supported formats include fractional core counts (e.g. "0.5") and
+// millicores using the Kubernetes-style suffix (e.g. "500m").
+func ParseCPU(value string) (int64, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, nil
+	}
+	var cores float64
+	var err error
+	if strings.HasSuffix(trimmed, "m") || strings.HasSuffix(trimmed, "M") {
+		milli := strings.TrimSpace(trimmed[:len(trimmed)-1])
+		if milli == "" {
+			return 0, fmt.Errorf("invalid cpu quantity %q", value)
+		}
+		var milliVal float64
+		milliVal, err = strconv.ParseFloat(milli, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid cpu quantity %q: %w", value, err)
+		}
+		cores = milliVal / 1000.0
+	} else {
+		cores, err = strconv.ParseFloat(trimmed, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid cpu quantity %q: %w", value, err)
+		}
+	}
+	if cores <= 0 {
+		return 0, fmt.Errorf("invalid cpu quantity %q: must be positive", value)
+	}
+	nano := math.Round(cores * NanoCPUs)
+	if nano < 1 {
+		nano = 1
+	}
+	if nano > math.MaxInt64 {
+		return 0, fmt.Errorf("invalid cpu quantity %q: exceeds supported range", value)
+	}
+	return int64(nano), nil
+}
+
+// ParseMemory converts textual memory limits like "512Mi" into bytes.
+func ParseMemory(value string) (int64, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, nil
+	}
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasSuffix(lower, "kib"), strings.HasSuffix(lower, "mib"), strings.HasSuffix(lower, "gib"), strings.HasSuffix(lower, "tib"), strings.HasSuffix(lower, "pib"), strings.HasSuffix(lower, "eib"):
+		// already in binary units understood by go-units
+	case strings.HasSuffix(lower, "ki"), strings.HasSuffix(lower, "mi"), strings.HasSuffix(lower, "gi"), strings.HasSuffix(lower, "ti"), strings.HasSuffix(lower, "pi"), strings.HasSuffix(lower, "ei"):
+		trimmed += "B"
+	}
+	bytes, err := units.RAMInBytes(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory quantity %q: %w", value, err)
+	}
+	if bytes <= 0 {
+		return 0, fmt.Errorf("invalid memory quantity %q: must be positive", value)
+	}
+	return bytes, nil
+}

--- a/internal/runtime/docker/docker_unit_test.go
+++ b/internal/runtime/docker/docker_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
 )
 
 func TestBuildConfigsVolumes(t *testing.T) {
@@ -43,5 +44,52 @@ func TestBuildConfigsVolumeParseError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "/host/data:var/data") {
 		t.Fatalf("error missing bind spec: %v", err)
+	}
+}
+
+func TestBuildConfigsResources(t *testing.T) {
+	spec := runtime.StartSpec{
+		Image: "example",
+		Resources: &stack.Resources{
+			CPU:               "500m",
+			Memory:            "256Mi",
+			MemoryReservation: "128Mi",
+		},
+	}
+	_, hostCfg, err := buildConfigs(spec)
+	if err != nil {
+		t.Fatalf("buildConfigs returned error: %v", err)
+	}
+
+	if got, want := hostCfg.Resources.NanoCPUs, int64(500_000_000); got != want {
+		t.Fatalf("unexpected NanoCPUs: got %d want %d", got, want)
+	}
+	if got, want := hostCfg.Resources.CPUPeriod, int64(100000); got != want {
+		t.Fatalf("unexpected CPUPeriod: got %d want %d", got, want)
+	}
+	if got, want := hostCfg.Resources.CPUQuota, int64(50000); got != want {
+		t.Fatalf("unexpected CPUQuota: got %d want %d", got, want)
+	}
+	if got, want := hostCfg.Resources.Memory, int64(268435456); got != want {
+		t.Fatalf("unexpected memory limit: got %d want %d", got, want)
+	}
+	if got, want := hostCfg.Resources.MemoryReservation, int64(134217728); got != want {
+		t.Fatalf("unexpected memory reservation: got %d want %d", got, want)
+	}
+}
+
+func TestBuildConfigsResourcesInvalid(t *testing.T) {
+	spec := runtime.StartSpec{
+		Image: "example",
+		Resources: &stack.Resources{
+			CPU: "bogus",
+		},
+	}
+	_, _, err := buildConfigs(spec)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse cpu") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -84,6 +84,9 @@ type StartSpec struct {
 	// Health optionally configures readiness probing for the instance.
 	Health *stack.Health
 
+	// Resources describes requested resource constraints.
+	Resources *stack.Resources
+
 	// Service retains the original stack definition when available. This is
 	// primarily used by existing runtimes that need access to additional
 	// configuration that has not yet been promoted onto StartSpec.

--- a/internal/stack/types.go
+++ b/internal/stack/types.go
@@ -18,4 +18,5 @@ type (
 	UpdatePolicy  = config.UpdateStrategy
 	RestartPolicy = config.RestartPolicy
 	Backoff       = config.BackoffSpec
+	Resources     = config.Resources
 )


### PR DESCRIPTION
## Summary
- add a resources section to service definitions with validation helpers
- propagate resource hints through start specs to the Docker runtime and apply container limits
- document the new CPU and memory settings in the example stack files

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e42568ac6c83258ec78be8386b8049