### PR TITLE
Handle Docker OOM exits and add regression tests

### DIFF
--- a/internal/runtime/docker/docker_unit_test.go
+++ b/internal/runtime/docker/docker_unit_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
+
 	"github.com/Paintersrp/orco/internal/runtime"
 	"github.com/Paintersrp/orco/internal/stack"
 )
@@ -91,5 +93,21 @@ func TestBuildConfigsResourcesInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parse cpu") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitOutcomeExitErrorOOM(t *testing.T) {
+	outcome := waitOutcome{
+		status:      container.WaitResponse{StatusCode: 137},
+		oomKilled:   true,
+		memoryLimit: "256Mi",
+	}
+	err := waitOutcomeExitError(outcome)
+	if err == nil {
+		t.Fatalf("expected error for oom exit")
+	}
+	want := "container terminated by the kernel OOM killer (memory limit 256Mi): container exited with status 137"
+	if got := err.Error(); got != want {
+		t.Fatalf("unexpected error message: got %q want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- detect Docker container OOM kills by inspecting state after wait and wrap exit errors with an explicit OOM message that includes the configured memory limit when available
- ensure supervisors propagate the OOM error string unchanged so status tracking can report the reason
- add regression tests covering the Docker runtime, supervisor, and status tracker for OOM scenarios

## Testing
- go test ./internal/runtime/docker -run TestWaitOutcomeExitErrorOOM -count=1
- go test ./internal/engine -run TestSupervisorPropagatesOOMError -count=1
- go test ./internal/cli -run TestStatusTrackerRecordsOOMError -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e42dfa2b0c832588cfb1b0b4845412