### PR TITLE
Ensure Docker memory hints enforce hard limits

### DIFF
--- a/internal/runtime/docker/docker.go
+++ b/internal/runtime/docker/docker.go
@@ -684,6 +684,11 @@ func buildConfigs(spec runtime.StartSpec) (*container.Config, *container.HostCon
 				return nil, nil, fmt.Errorf("parse memory: %w", err)
 			}
 			limits.Memory = bytes
+			// With cgroups v2 Docker requires the swap limit to be set
+			// alongside the memory limit to enforce hard caps. Matching
+			// the values disables swap usage and mirrors the behavior
+			// expected by resource hints.
+			limits.MemorySwap = bytes
 		}
 		if strings.TrimSpace(spec.Resources.MemoryReservation) != "" {
 			bytes, err := resources.ParseMemory(spec.Resources.MemoryReservation)

--- a/internal/runtime/docker/docker_unit_test.go
+++ b/internal/runtime/docker/docker_unit_test.go
@@ -75,6 +75,9 @@ func TestBuildConfigsResources(t *testing.T) {
 	if got, want := hostCfg.Resources.Memory, int64(268435456); got != want {
 		t.Fatalf("unexpected memory limit: got %d want %d", got, want)
 	}
+	if got, want := hostCfg.Resources.MemorySwap, int64(268435456); got != want {
+		t.Fatalf("unexpected memory swap limit: got %d want %d", got, want)
+	}
 	if got, want := hostCfg.Resources.MemoryReservation, int64(134217728); got != want {
 		t.Fatalf("unexpected memory reservation: got %d want %d", got, want)
 	}


### PR DESCRIPTION
## Summary
- set the Docker memory swap limit to match the configured memory hint so cgroups v2 enforces the cap
- extend the Docker runtime unit test to cover the swap limit configuration

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e437e7ef8883258314cdeedee0ee66