### PR TITLE
Surface crash errors in status messages

### DIFF
--- a/internal/cli/status_tracker.go
+++ b/internal/cli/status_tracker.go
@@ -204,18 +204,27 @@ func (t *statusTracker) Apply(evt engine.Event) {
 }
 
 func formatEventMessage(evt engine.Event) string {
-	message := ""
-	if evt.Message != "" {
-		message = evt.Message
-	} else if evt.Err != nil {
-		message = evt.Err.Error()
+	message := strings.TrimSpace(evt.Message)
+	errMsg := ""
+	if evt.Err != nil {
+		errMsg = strings.TrimSpace(evt.Err.Error())
 	}
-	if evt.Replica >= 0 && message != "" {
-		message = fmt.Sprintf("replica %d: %s", evt.Replica, message)
+
+	switch {
+	case message != "" && errMsg != "":
+		message = fmt.Sprintf("%s: %s", message, errMsg)
+	case message == "" && errMsg != "":
+		message = errMsg
 	}
-	if evt.Replica >= 0 && message == "" {
-		message = fmt.Sprintf("replica %d", evt.Replica)
+
+	if evt.Replica >= 0 {
+		if message != "" {
+			message = fmt.Sprintf("replica %d: %s", evt.Replica, message)
+		} else {
+			message = fmt.Sprintf("replica %d", evt.Replica)
+		}
 	}
+
 	return cliutil.RedactSecrets(message)
 }
 

--- a/internal/cli/status_tracker_test.go
+++ b/internal/cli/status_tracker_test.go
@@ -124,6 +124,7 @@ func TestStatusTrackerRecordsOOMError(t *testing.T) {
 		Service:   "api",
 		Replica:   0,
 		Type:      engine.EventTypeCrashed,
+		Message:   "instance crashed",
 		Err:       oomErr,
 		Timestamp: base,
 	})
@@ -131,6 +132,9 @@ func TestStatusTrackerRecordsOOMError(t *testing.T) {
 	snap := tracker.Snapshot()["api"]
 	if snap.State != engine.EventTypeCrashed {
 		t.Fatalf("expected crashed state, got %q", snap.State)
+	}
+	if !strings.Contains(snap.Message, "instance crashed") {
+		t.Fatalf("expected event message to be included, got %q", snap.Message)
 	}
 	if !strings.Contains(snap.Message, "OOM killer") {
 		t.Fatalf("expected OOM reason in message, got %q", snap.Message)


### PR DESCRIPTION
## Summary
- include the underlying error text when formatting status tracker messages so crash reasons (including OOM limits) appear in status output
- extend the status tracker OOM test to assert the synthesized message preserves both the event text and kernel OOM description

## Testing
- not run (the environment hung on `go test ./internal/cli -run TestStatusTracker -count=1`)


------
https://chatgpt.com/codex/tasks/task_e_68e439be5d908325859d22b55e5cac2b