### PR TITLE
Add persistent log sink with rotation controls

### DIFF
--- a/internal/logmux/mux_test.go
+++ b/internal/logmux/mux_test.go
@@ -1,6 +1,14 @@
 package logmux
 
 import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -60,6 +68,196 @@ func TestMuxFansInMultipleSources(t *testing.T) {
 	if len(workerMessages) != 1 || workerMessages[0] != "worker ready" {
 		t.Fatalf("unexpected worker messages: %v", workerMessages)
 	}
+}
+
+func TestMuxPersistsNormalizedEvents(t *testing.T) {
+	dir := t.TempDir()
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	mux := New(4, WithDirectory(dir), withClock(clock.Now))
+	src := make(chan engine.Event, 3)
+	mux.Add(src)
+
+	go func() {
+		src <- engine.Event{Service: "api", Type: engine.EventTypeLog, Message: "INFO: ready"}
+		clock.Advance(time.Second)
+		src <- engine.Event{Service: "api", Type: engine.EventTypeLog, Message: "stderr", Source: runtime.LogSourceStderr}
+		close(src)
+	}()
+
+	go mux.Close()
+
+	for range mux.Output() {
+	}
+
+	serviceDir := filepath.Join(dir, "api")
+	entries, err := os.ReadDir(serviceDir)
+	if err != nil {
+		t.Fatalf("expected log directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected single log file, got %d", len(entries))
+	}
+
+	filePath := filepath.Join(serviceDir, entries[0].Name())
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("open log file: %v", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var records []engine.Event
+	for scanner.Scan() {
+		var evt engine.Event
+		if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		records = append(records, evt)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if len(records) != 2 {
+		t.Fatalf("expected two events, got %d", len(records))
+	}
+	if records[0].Level != "info" || records[0].Source != runtime.LogSourceStdout {
+		t.Fatalf("unexpected normalization: %+v", records[0])
+	}
+	if records[1].Source != runtime.LogSourceStderr {
+		t.Fatalf("expected stderr source, got %+v", records[1])
+	}
+	if records[0].Timestamp.IsZero() || records[1].Timestamp.IsZero() {
+		t.Fatalf("expected timestamps to be populated")
+	}
+}
+
+func TestMuxRotatesAndPrunesLogs(t *testing.T) {
+	dir := t.TempDir()
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	mux := New(1,
+		WithDirectory(dir),
+		WithMaxFileSize(120),
+		WithMaxTotalSize(240),
+		WithMaxFileAge(time.Second),
+		withClock(clock.Now),
+	)
+
+	src := make(chan engine.Event, 8)
+	mux.Add(src)
+
+	go func() {
+		for i := 0; i < 6; i++ {
+			src <- engine.Event{Service: "api", Type: engine.EventTypeLog, Message: strings.Repeat("x", 64)}
+			clock.Advance(500 * time.Millisecond)
+		}
+		close(src)
+	}()
+
+	go mux.Close()
+	for range mux.Output() {
+	}
+
+	serviceDir := filepath.Join(dir, "api")
+	entries, err := os.ReadDir(serviceDir)
+	if err != nil {
+		t.Fatalf("expected log directory: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("expected rotated files")
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	var totalSize int64
+	now := clock.Now()
+	cutoff := now.Add(-time.Second)
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatalf("stat file: %v", err)
+		}
+		totalSize += info.Size()
+		if info.ModTime().Before(cutoff) {
+			t.Fatalf("expected pruning by age to remove %s", entry.Name())
+		}
+	}
+	if totalSize > 240 {
+		t.Fatalf("expected pruning by size, got %d bytes", totalSize)
+	}
+}
+
+func TestMuxPersistsDropMetadata(t *testing.T) {
+	dir := t.TempDir()
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	mux := New(1, WithDirectory(dir), withClock(clock.Now))
+	src := make(chan engine.Event)
+	mux.Add(src)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 4; i++ {
+			src <- engine.Event{Service: "api", Type: engine.EventTypeLog, Message: fmt.Sprintf("line-%d", i)}
+			clock.Advance(time.Millisecond)
+		}
+		close(src)
+	}()
+
+	<-done
+	go mux.Close()
+	for range mux.Output() {
+	}
+
+	serviceDir := filepath.Join(dir, "api")
+	entries, err := os.ReadDir(serviceDir)
+	if err != nil {
+		t.Fatalf("expected log directory: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("expected log file")
+	}
+
+	var metaSeen bool
+	for _, entry := range entries {
+		file, err := os.Open(filepath.Join(serviceDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("open file: %v", err)
+		}
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			var evt engine.Event
+			if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if evt.Source == runtime.LogSourceSystem && strings.HasPrefix(evt.Message, "dropped=") {
+				metaSeen = true
+			}
+		}
+		file.Close()
+	}
+	if !metaSeen {
+		t.Fatalf("expected drop metadata to be recorded")
+	}
+}
+
+type fakeClock struct {
+	now time.Time
+	mu  sync.Mutex
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
 }
 
 func TestMuxEmitsDropMetaEvents(t *testing.T) {


### PR DESCRIPTION
## Summary
- extend the log mux with an optional NDJSON sink that normalizes events, rotates files, and prunes old data based on size, age, and volume thresholds
- hook the mux-backed sink into the CLI event tracking pipeline with environment-configurable retention settings
- add log mux unit tests that verify event persistence, rotation/pruning behavior, and drop metadata capture

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e460dad6348325bf441189ac907059