### PR TITLE
Add stack-scoped NDJSON log sink and update event mux

### DIFF
--- a/internal/cli/apply_integration_test.go
+++ b/internal/cli/apply_integration_test.go
@@ -42,8 +42,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -52,11 +57,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {
@@ -170,8 +170,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -180,11 +185,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {
@@ -286,8 +286,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 256)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	var (
@@ -303,11 +308,6 @@ services:
 			mu.Unlock()
 		}
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {

--- a/internal/cli/logs_integration_test.go
+++ b/internal/cli/logs_integration_test.go
@@ -198,7 +198,7 @@ func startDeployment(t *testing.T, ctx *context) {
 	}
 
 	events := make(chan engine.Event, 256)
-	tracked, release := ctx.trackEvents(events, cap(events))
+	tracked, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	drained := make(chan struct{})
 	go func() {
 		for range tracked {

--- a/internal/cli/restart_integration_test.go
+++ b/internal/cli/restart_integration_test.go
@@ -37,8 +37,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -47,11 +52,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {
@@ -143,8 +143,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -153,11 +158,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -57,7 +57,7 @@ func runStackTUI(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (
 	}()
 
 	events := make(chan engine.Event, 256)
-	trackedEvents, releaseStream := ctx.trackEvents(events, cap(events))
+	trackedEvents, releaseStream := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 
 	var forwarder sync.WaitGroup
 	forwarder.Add(1)
@@ -119,7 +119,7 @@ func runUpInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocume
 
 func runUpNonInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (retErr error) {
 	events := make(chan engine.Event, 64)
-	trackedEvents, releaseStream := ctx.trackEvents(events, cap(events))
+	trackedEvents, releaseStream := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	var printer sync.WaitGroup
 	printer.Add(1)
 	go func() {


### PR DESCRIPTION
## Summary
- persist every event through the log mux so lifecycle transitions are recorded alongside logs
- add a stack-aware NDJSON file sink option and update CLI wiring to pass the current stack name
- extend log mux coverage for stack directories and update integration tests to match the new API

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e57f8ec604832580fc6f0a03bec621