### PR TITLE
Scope log retention by stack directories

### DIFF
--- a/internal/cli/apply_integration_test.go
+++ b/internal/cli/apply_integration_test.go
@@ -42,8 +42,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -52,11 +57,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {
@@ -170,8 +170,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -180,11 +185,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {
@@ -286,8 +286,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 256)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	var (
@@ -303,11 +308,6 @@ services:
 			mu.Unlock()
 		}
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {

--- a/internal/cli/logs_integration_test.go
+++ b/internal/cli/logs_integration_test.go
@@ -198,7 +198,7 @@ func startDeployment(t *testing.T, ctx *context) {
 	}
 
 	events := make(chan engine.Event, 256)
-	tracked, release := ctx.trackEvents(events, cap(events))
+	tracked, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	drained := make(chan struct{})
 	go func() {
 		for range tracked {

--- a/internal/cli/restart_integration_test.go
+++ b/internal/cli/restart_integration_test.go
@@ -37,8 +37,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -47,11 +52,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {
@@ -143,8 +143,13 @@ services:
 		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
 	}
 
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
 	events := make(chan engine.Event, 128)
-	trackedEvents, release := ctx.trackEvents(events, cap(events))
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	defer release()
 
 	done := make(chan struct{})
@@ -153,11 +158,6 @@ services:
 		}
 		close(done)
 	}()
-
-	doc, err := ctx.loadStack()
-	if err != nil {
-		t.Fatalf("load stack: %v", err)
-	}
 
 	deployment, err := ctx.getOrchestrator().Up(stdcontext.Background(), doc.File, doc.Graph, events)
 	if err != nil {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -11,6 +11,7 @@ import (
 
 type sinkConfigView struct {
 	Directory    string
+	Stack        string
 	MaxFileSize  int64
 	MaxTotalSize int64
 	MaxFileAge   time.Duration
@@ -35,6 +36,7 @@ func extractSinkConfig(t *testing.T, opts []logmux.SinkOption) sinkConfigView {
 	cfgVal := reflect.NewAt(cfgField.Type(), cfgPtr).Elem()
 	return sinkConfigView{
 		Directory:    cfgVal.FieldByName("directory").String(),
+		Stack:        cfgVal.FieldByName("stack").String(),
 		MaxFileSize:  cfgVal.FieldByName("maxFileSize").Int(),
 		MaxTotalSize: cfgVal.FieldByName("maxTotalSize").Int(),
 		MaxFileAge:   time.Duration(cfgVal.FieldByName("maxFileAge").Int()),
@@ -55,9 +57,12 @@ func TestRootCommandLogRetentionFromEnv(t *testing.T) {
 		t.Fatalf("expected directory %s, got %s", dir, ctx.logRetention.Directory)
 	}
 
-	cfg := extractSinkConfig(t, ctx.logSinkOptions())
+	cfg := extractSinkConfig(t, ctx.logSinkOptions("Demo"))
 	if cfg.Directory != dir {
 		t.Fatalf("expected sink directory %s, got %s", dir, cfg.Directory)
+	}
+	if cfg.Stack != "demo" {
+		t.Fatalf("expected stack directory demo, got %s", cfg.Stack)
 	}
 	if cfg.MaxFileSize != 128 {
 		t.Fatalf("expected max file size 128, got %d", cfg.MaxFileSize)
@@ -106,9 +111,12 @@ func TestRootCommandLogRetentionFlagsOverride(t *testing.T) {
 		t.Fatalf("expected overridden directory %s, got %s", overrideDir, ctx.logRetention.Directory)
 	}
 
-	cfg := extractSinkConfig(t, ctx.logSinkOptions())
+	cfg := extractSinkConfig(t, ctx.logSinkOptions("demo"))
 	if cfg.Directory != overrideDir {
 		t.Fatalf("expected sink directory %s, got %s", overrideDir, cfg.Directory)
+	}
+	if cfg.Stack != "demo" {
+		t.Fatalf("expected stack directory demo, got %s", cfg.Stack)
 	}
 	if cfg.MaxFileSize != 256 {
 		t.Fatalf("expected max file size 256, got %d", cfg.MaxFileSize)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -57,7 +57,7 @@ func runStackTUI(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (
 	}()
 
 	events := make(chan engine.Event, 256)
-	trackedEvents, releaseStream := ctx.trackEvents(events, cap(events))
+	trackedEvents, releaseStream := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 
 	var forwarder sync.WaitGroup
 	forwarder.Add(1)
@@ -119,7 +119,7 @@ func runUpInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocume
 
 func runUpNonInteractive(cmd *cobra.Command, ctx *context, doc *cliutil.StackDocument) (retErr error) {
 	events := make(chan engine.Event, 64)
-	trackedEvents, releaseStream := ctx.trackEvents(events, cap(events))
+	trackedEvents, releaseStream := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
 	var printer sync.WaitGroup
 	printer.Add(1)
 	go func() {


### PR DESCRIPTION
## Summary
- add a stack-aware log sink option that nests service logs beneath stack directories
- propagate the active stack name into CLI log sink configuration and update integration tests accordingly
- cover stack directory behavior in log mux and CLI configuration tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e58242f3508325b24a3708f0567dae