### PR TITLE
Add stack-level logging retention configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ Persistent CLI flags configure how the on-disk log sink rotates and prunes files
 
 Each option can also be provided via the `ORCO_LOG_DIR`, `ORCO_LOG_MAX_FILE_SIZE`, `ORCO_LOG_MAX_TOTAL_SIZE`, `ORCO_LOG_MAX_FILE_AGE`, and `ORCO_LOG_MAX_FILE_COUNT` environment variables, respectively.
 
+Stack manifests may declare default retention under a top-level `logging` key. These defaults apply to all commands unless overridden via flags or environment variables:
+
+```
+logging:
+  directory: ./logs
+  maxFileSize: 128000
+  maxTotalSize: 512000
+  maxFileAge: 1h
+  maxFileCount: 10
+```
+
+Relative paths are resolved against the stack's working directory.
+
 ## TUI
 
 The terminal UI presents a live status table and tailing logs:

--- a/examples/demo-stack.yaml
+++ b/examples/demo-stack.yaml
@@ -4,6 +4,13 @@ stack:
   name: demo
   workdir: ./
 
+logging:
+  directory: ./logs
+  maxFileSize: 131072
+  maxTotalSize: 524288
+  maxFileAge: 1h
+  maxFileCount: 8
+
 defaults:
   restartPolicy:
     maxRetries: 5

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -121,6 +123,138 @@ func TestRootCommandLogRetentionFlagsOverride(t *testing.T) {
 	}
 	if cfg.MaxFileCount != 5 {
 		t.Fatalf("expected max file count 5, got %d", cfg.MaxFileCount)
+	}
+
+	_ = cmd
+}
+
+func TestContextLoadStackAppliesLoggingConfig(t *testing.T) {
+	cmd, ctx := newRootCommand()
+	_ = cmd
+
+	stackDir := t.TempDir()
+	stackPath := filepath.Join(stackDir, "stack.yaml")
+	contents := `version: "0.1"
+
+stack:
+  name: demo
+  workdir: .
+
+logging:
+  directory: ./logs
+  maxFileSize: 128
+  maxTotalSize: 256
+  maxFileAge: 45s
+  maxFileCount: 4
+
+services:
+  api:
+    runtime: process
+    command: ["/bin/true"]
+    health:
+      http:
+        url: http://localhost:8080/healthz
+        expectStatus: [200]
+`
+	if err := os.WriteFile(stackPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write stack file: %v", err)
+	}
+
+	*ctx.stackFile = stackPath
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+	t.Cleanup(func() {
+		if doc != nil && doc.Graph != nil {
+			_ = doc.Graph
+		}
+	})
+
+	expectedDir := filepath.Join(doc.File.Stack.Workdir, "logs")
+	if ctx.logRetention.Directory != expectedDir {
+		t.Fatalf("expected log directory %s, got %s", expectedDir, ctx.logRetention.Directory)
+	}
+	if ctx.logRetention.MaxFileSize != 128 {
+		t.Fatalf("expected max file size 128, got %d", ctx.logRetention.MaxFileSize)
+	}
+	if ctx.logRetention.MaxTotalSize != 256 {
+		t.Fatalf("expected max total size 256, got %d", ctx.logRetention.MaxTotalSize)
+	}
+	if ctx.logRetention.MaxFileAge != 45*time.Second {
+		t.Fatalf("expected max file age 45s, got %s", ctx.logRetention.MaxFileAge)
+	}
+	if ctx.logRetention.MaxFileCount != 4 {
+		t.Fatalf("expected max file count 4, got %d", ctx.logRetention.MaxFileCount)
+	}
+}
+
+func TestContextLoadStackLoggingRespectsOverrides(t *testing.T) {
+	cmd, ctx := newRootCommand()
+
+	overrideDir := t.TempDir()
+	if err := cmd.PersistentFlags().Set("log-dir", overrideDir); err != nil {
+		t.Fatalf("set log-dir flag: %v", err)
+	}
+	if err := cmd.PersistentFlags().Set("log-max-file-size", "512"); err != nil {
+		t.Fatalf("set log-max-file-size flag: %v", err)
+	}
+	if err := cmd.PersistentFlags().Set("log-max-total-size", "1024"); err != nil {
+		t.Fatalf("set log-max-total-size flag: %v", err)
+	}
+	if err := cmd.PersistentFlags().Set("log-max-file-age", "90s"); err != nil {
+		t.Fatalf("set log-max-file-age flag: %v", err)
+	}
+	if err := cmd.PersistentFlags().Set("log-max-files", "6"); err != nil {
+		t.Fatalf("set log-max-files flag: %v", err)
+	}
+
+	stackDir := t.TempDir()
+	stackPath := filepath.Join(stackDir, "stack.yaml")
+	if err := os.WriteFile(stackPath, []byte(`version: "0.1"
+
+stack:
+  name: demo
+  workdir: .
+
+logging:
+  directory: ./logs
+  maxFileSize: 128
+  maxTotalSize: 256
+  maxFileAge: 30s
+  maxFileCount: 3
+
+services:
+  api:
+    runtime: process
+    command: ["/bin/true"]
+    health:
+      http:
+        url: http://localhost:8080/healthz
+        expectStatus: [200]
+`), 0o644); err != nil {
+		t.Fatalf("write stack file: %v", err)
+	}
+
+	*ctx.stackFile = stackPath
+	if _, err := ctx.loadStack(); err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
+	if ctx.logRetention.Directory != overrideDir {
+		t.Fatalf("expected directory override %s, got %s", overrideDir, ctx.logRetention.Directory)
+	}
+	if ctx.logRetention.MaxFileSize != 512 {
+		t.Fatalf("expected max file size override 512, got %d", ctx.logRetention.MaxFileSize)
+	}
+	if ctx.logRetention.MaxTotalSize != 1024 {
+		t.Fatalf("expected max total size override 1024, got %d", ctx.logRetention.MaxTotalSize)
+	}
+	if ctx.logRetention.MaxFileAge != 90*time.Second {
+		t.Fatalf("expected max file age override 90s, got %s", ctx.logRetention.MaxFileAge)
+	}
+	if ctx.logRetention.MaxFileCount != 6 {
+		t.Fatalf("expected max file count override 6, got %d", ctx.logRetention.MaxFileCount)
 	}
 
 	_ = cmd

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -36,6 +36,13 @@ func Load(path string) (*Stack, error) {
 	resolvedWorkdir := resolveWorkdir(stackDir, os.ExpandEnv(doc.Stack.Workdir))
 	doc.Stack.Workdir = resolvedWorkdir
 
+	if doc.Logging != nil {
+		doc.Logging.Directory = os.ExpandEnv(doc.Logging.Directory)
+		if doc.Logging.Directory != "" && !filepath.IsAbs(doc.Logging.Directory) {
+			doc.Logging.Directory = filepath.Clean(filepath.Join(resolvedWorkdir, doc.Logging.Directory))
+		}
+	}
+
 	for name, svc := range doc.Services {
 		if svc == nil {
 			continue


### PR DESCRIPTION
## Summary
- allow stack manifests to configure default log retention and resolve paths relative to the stack workdir
- track whether log retention options were set via flags or environment variables and respect CLI overrides
- document the new logging block and extend tests/examples accordingly

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e58addd954832595f1fa4ef7ddfc45