### PR TITLE
Add proxy configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ services:
     replicas: 1
 ```
 
+### HTTP proxy configuration
+
+Stacks may optionally define an HTTP edge proxy to expose multiple services behind a single listener. The proxy supports matching on request path prefixes and exact header values, with optional static asset serving for compiled front-end bundles:
+
+```yaml
+proxy:
+  assets:
+    directory: ./web/dist
+    index: index.html
+  routes:
+    - pathPrefix: /api/
+      service: api
+      port: 8080
+      stripPathPrefix: true
+    - headers:
+        X-Debug: "1"
+      service: api
+      port: 8081
+```
+
+Each route forwards traffic to the named service on the specified container port. A route must define either `pathPrefix` or one or more header matches (or both). When `stripPathPrefix` is true, the matched prefix is removed before proxying the request. Static assets are resolved relative to the stack's working directory, making them easy to embed alongside application code. The full configuration is demonstrated in `examples/proxy-stack.yaml`.
+
 Key behaviors:
 
 - `dependsOn.require` controls whether Orco waits for dependencies to start, exist, or reach readiness.

--- a/examples/proxy-stack.yaml
+++ b/examples/proxy-stack.yaml
@@ -1,0 +1,45 @@
+version: 0.1
+
+stack:
+  name: proxy-demo
+  workdir: ./
+
+proxy:
+  assets:
+    directory: ./web/dist
+    index: index.html
+  routes:
+    - pathPrefix: /api/
+      service: api
+      port: 8080
+      stripPathPrefix: true
+    - headers:
+        X-Debug: "1"
+      service: api
+      port: 8081
+      stripPathPrefix: false
+
+services:
+  api:
+    image: ghcr.io/acme/api:latest
+    runtime: docker
+    ports: ["8080:8080", "8081:8081"]
+    env:
+      LOG_LEVEL: info
+    health:
+      http:
+        url: http://localhost:8080/health
+        expectStatus: [200]
+
+  frontend:
+    runtime: process
+    command: ["./bin/frontend", "--port=3000"]
+    dependsOn:
+      - target: api
+        require: ready
+    env:
+      API_BASE_URL: http://localhost:8080
+    health:
+      http:
+        url: http://localhost:3000/healthz
+        expectStatus: [200]


### PR DESCRIPTION
## Summary
- add a proxy specification to the stack schema with validation helpers
- resolve proxy configuration in the loader and cover valid/invalid cases with tests
- document proxy usage and provide an example stack manifest

## Testing
- go test -v ./internal/config

------
https://chatgpt.com/codex/tasks/task_e_68e5b03938d08325ba68597ad1f3d1ee