### PR TITLE
Add proxy runtime integration and routing test

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Paintersrp/orco/internal/runtime"
 	"github.com/Paintersrp/orco/internal/runtime/docker"
 	"github.com/Paintersrp/orco/internal/runtime/process"
+	proxyruntime "github.com/Paintersrp/orco/internal/runtime/proxy"
 	"github.com/Paintersrp/orco/internal/stack"
 )
 
@@ -151,8 +152,9 @@ func (c *context) applyStackLogRetention(doc *cliutil.StackDocument) {
 func (c *context) getOrchestrator() *engine.Orchestrator {
 	if c.orchestrator == nil {
 		c.orchestrator = engine.NewOrchestrator(runtime.Registry{
-			"docker":  docker.New(),
-			"process": process.New(),
+			"docker":                 docker.New(),
+			"process":                process.New(),
+			proxyruntime.RuntimeName: proxyruntime.New(),
 		})
 	}
 	return c.orchestrator

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -96,6 +96,53 @@ type ProxyAssetSpec struct {
 	Index     string `yaml:"index"`
 }
 
+// Clone creates a deep copy of the proxy configuration.
+func (p *ProxySpec) Clone() *ProxySpec {
+	if p == nil {
+		return nil
+	}
+	cp := &ProxySpec{}
+	if len(p.Routes) > 0 {
+		cp.Routes = make([]*ProxyRoute, 0, len(p.Routes))
+		for _, route := range p.Routes {
+			cp.Routes = append(cp.Routes, route.Clone())
+		}
+	}
+	if p.Assets != nil {
+		cp.Assets = p.Assets.Clone()
+	}
+	return cp
+}
+
+// Clone creates a deep copy of the proxy route configuration.
+func (r *ProxyRoute) Clone() *ProxyRoute {
+	if r == nil {
+		return nil
+	}
+	cp := &ProxyRoute{
+		PathPrefix:      r.PathPrefix,
+		Service:         r.Service,
+		Port:            r.Port,
+		StripPathPrefix: r.StripPathPrefix,
+	}
+	if len(r.Headers) > 0 {
+		cp.Headers = make(map[string]string, len(r.Headers))
+		for k, v := range r.Headers {
+			cp.Headers[k] = v
+		}
+	}
+	return cp
+}
+
+// Clone creates a deep copy of the proxy asset configuration.
+func (a *ProxyAssetSpec) Clone() *ProxyAssetSpec {
+	if a == nil {
+		return nil
+	}
+	cp := *a
+	return &cp
+}
+
 // ServiceSpec describes an individual service in the stack.
 type ServiceSpec struct {
 	Image           string            `yaml:"image"`

--- a/internal/engine/supervisor_test.go
+++ b/internal/engine/supervisor_test.go
@@ -39,7 +39,7 @@ func TestSupervisorRestartsOnUnready(t *testing.T) {
 	}
 
 	events := make(chan Event, 32)
-	sup := newSupervisor("web", 0, svc, rt, events)
+	sup := newSupervisor("web", 0, svc, rt, events, nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 
@@ -175,7 +175,7 @@ func TestSupervisorBackoffJitter(t *testing.T) {
 
 	delayCh := make(chan time.Duration, 8)
 	var delays []time.Duration
-	sup := newSupervisor("db", 0, svc, rt, make(chan Event, 32))
+	sup := newSupervisor("db", 0, svc, rt, make(chan Event, 32), nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error {
 		delayCh <- d
@@ -234,7 +234,7 @@ func TestSupervisorMaxRetriesEmitsFailed(t *testing.T) {
 	events := make(chan Event, 32)
 	rt := &fakeRuntime{instances: []*fakeInstance{inst1, inst2}}
 
-	sup := newSupervisor("api", 0, svc, rt, events)
+	sup := newSupervisor("api", 0, svc, rt, events, nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 
@@ -295,7 +295,7 @@ func TestSupervisorPropagatesOOMError(t *testing.T) {
 	events := make(chan Event, 8)
 	rt := &fakeRuntime{instances: []*fakeInstance{inst}}
 
-	sup := newSupervisor("api", 0, svc, rt, events)
+	sup := newSupervisor("api", 0, svc, rt, events, nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 
@@ -360,7 +360,7 @@ func TestSupervisorStartFailuresEmitFailedEvent(t *testing.T) {
 		startCh:   make(chan struct{}, 2),
 	}
 
-	sup := newSupervisor("api", 0, svc, rt, events)
+	sup := newSupervisor("api", 0, svc, rt, events, nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 
@@ -431,7 +431,7 @@ func TestSupervisorCancelDuringBackoffDeliversCancellation(t *testing.T) {
 		startCh:   make(chan struct{}, 1),
 	}
 
-	sup := newSupervisor("api", 0, svc, rt, nil)
+	sup := newSupervisor("api", 0, svc, rt, nil, nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 
 	sleepCalled := make(chan struct{})
@@ -608,7 +608,7 @@ func TestSupervisorManualRestart(t *testing.T) {
 	rt := &fakeRuntime{instances: []*fakeInstance{first, second}, startCh: make(chan struct{}, 4)}
 
 	events := make(chan Event, 32)
-	sup := newSupervisor("api", 0, svc, rt, events)
+	sup := newSupervisor("api", 0, svc, rt, events, nil)
 	sup.jitter = func(d time.Duration) time.Duration { return d }
 	sup.sleep = func(ctx context.Context, d time.Duration) error { return nil }
 

--- a/internal/runtime/proxy/proxy.go
+++ b/internal/runtime/proxy/proxy.go
@@ -1,0 +1,364 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/textproto"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/probe"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
+)
+
+const (
+	// RuntimeName identifies the proxy runtime in stack manifests.
+	RuntimeName = "proxy"
+
+	listenAddrEnv     = "ORCO_PROXY_LISTEN"
+	targetHostEnv     = "ORCO_PROXY_TARGET_HOST"
+	defaultListenAddr = "127.0.0.1:8080"
+	defaultTargetHost = "127.0.0.1"
+)
+
+// New constructs a runtime that launches an in-process HTTP reverse proxy.
+func New() runtime.Runtime {
+	return &runtimeImpl{}
+}
+
+type runtimeImpl struct{}
+
+// Start launches the proxy server according to the supplied specification.
+func (r *runtimeImpl) Start(ctx context.Context, spec runtime.StartSpec) (runtime.Handle, error) {
+	if spec.Proxy == nil {
+		return nil, fmt.Errorf("proxy runtime for service %s requires proxy configuration", spec.Name)
+	}
+
+	cfg := spec.Proxy.Clone()
+	if cfg == nil {
+		return nil, fmt.Errorf("proxy runtime for service %s requires proxy configuration", spec.Name)
+	}
+
+	listenAddr := defaultListenAddr
+	explicitListen := false
+	if spec.Env != nil {
+		if addr := strings.TrimSpace(spec.Env[listenAddrEnv]); addr != "" {
+			listenAddr = addr
+			explicitListen = true
+		}
+	}
+	if !explicitListen {
+		if envAddr := strings.TrimSpace(os.Getenv(listenAddrEnv)); envAddr != "" {
+			listenAddr = envAddr
+		}
+	}
+
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("proxy listen %s: %w", listenAddr, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		_ = listener.Close()
+		return nil, ctx.Err()
+	default:
+	}
+
+	targetHost := defaultTargetHost
+	explicitTarget := false
+	if spec.Env != nil {
+		if host := strings.TrimSpace(spec.Env[targetHostEnv]); host != "" {
+			targetHost = host
+			explicitTarget = true
+		}
+	}
+	if !explicitTarget {
+		if envHost := strings.TrimSpace(os.Getenv(targetHostEnv)); envHost != "" {
+			targetHost = envHost
+		}
+	}
+
+	handler, err := newProxyHandler(cfg, targetHost)
+	if err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+
+	srv := &http.Server{Handler: handler}
+	inst := &proxyInstance{
+		server:   srv,
+		listener: listener,
+		ready:    make(chan struct{}),
+		done:     make(chan struct{}),
+		logs:     make(chan runtime.LogEntry, 1),
+	}
+
+	inst.logs <- runtime.LogEntry{
+		Message:   fmt.Sprintf("proxy listening on %s", listener.Addr().String()),
+		Source:    runtime.LogSourceSystem,
+		Level:     "info",
+		Timestamp: time.Now(),
+	}
+
+	go inst.serve()
+
+	close(inst.ready)
+
+	go func() {
+		<-ctx.Done()
+		_ = inst.server.Shutdown(context.Background())
+	}()
+
+	return inst, nil
+}
+
+type proxyInstance struct {
+	server   *http.Server
+	listener net.Listener
+
+	ready chan struct{}
+	done  chan struct{}
+
+	stopOnce sync.Once
+	waitErr  error
+
+	logs chan runtime.LogEntry
+}
+
+func (p *proxyInstance) WaitReady(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.ready:
+		return nil
+	}
+}
+
+func (p *proxyInstance) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.done:
+		return p.waitErr
+	}
+}
+
+func (p *proxyInstance) Health() <-chan probe.State {
+	return nil
+}
+
+func (p *proxyInstance) Stop(ctx context.Context) error {
+	var err error
+	p.stopOnce.Do(func() {
+		err = p.server.Shutdown(ctx)
+	})
+	return err
+}
+
+func (p *proxyInstance) Kill(ctx context.Context) error {
+	var err error
+	p.stopOnce.Do(func() {
+		err = p.server.Close()
+	})
+	return err
+}
+
+func (p *proxyInstance) Logs(ctx context.Context) (<-chan runtime.LogEntry, error) {
+	if ctx == nil {
+		return p.logs, nil
+	}
+
+	out := make(chan runtime.LogEntry, cap(p.logs))
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case entry, ok := <-p.logs:
+				if !ok {
+					return
+				}
+				select {
+				case out <- entry:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out, nil
+}
+
+func (p *proxyInstance) serve() {
+	err := p.server.Serve(p.listener)
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		p.waitErr = err
+	}
+	close(p.logs)
+	close(p.done)
+}
+
+type proxyHandler struct {
+	routes []*routeHandler
+	assets *assetHandler
+}
+
+func newProxyHandler(cfg *stack.Proxy, targetHost string) (http.Handler, error) {
+	if cfg == nil {
+		return nil, errors.New("proxy configuration is nil")
+	}
+
+	routes := make([]*routeHandler, 0, len(cfg.Routes))
+	for idx, rt := range cfg.Routes {
+		if rt == nil {
+			continue
+		}
+		if rt.Port <= 0 {
+			return nil, fmt.Errorf("proxy route %d: invalid port %d", idx, rt.Port)
+		}
+		route, err := buildRouteHandler(rt, targetHost)
+		if err != nil {
+			return nil, fmt.Errorf("proxy route %d: %w", idx, err)
+		}
+		routes = append(routes, route)
+	}
+
+	var assets *assetHandler
+	if cfg.Assets != nil && (cfg.Assets.Directory != "" || cfg.Assets.Index != "") {
+		assets = &assetHandler{directory: cfg.Assets.Directory, index: cfg.Assets.Index}
+	}
+
+	return &proxyHandler{routes: routes, assets: assets}, nil
+}
+
+func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, route := range h.routes {
+		if route.match(r) {
+			route.serve(w, r)
+			return
+		}
+	}
+	if h.assets != nil && h.assets.serve(w, r) {
+		return
+	}
+	http.NotFound(w, r)
+}
+
+type routeHandler struct {
+	pathPrefix string
+	headers    map[string]string
+	proxy      *httputil.ReverseProxy
+	strip      bool
+}
+
+func buildRouteHandler(rt *stack.ProxyRoute, host string) (*routeHandler, error) {
+	target := &url.URL{Scheme: "http", Host: fmt.Sprintf("%s:%d", host, rt.Port)}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	prefix := rt.PathPrefix
+	strip := rt.StripPathPrefix
+	proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+		if strip && prefix != "" && strings.HasPrefix(req.URL.Path, prefix) {
+			trimmed := strings.TrimPrefix(req.URL.Path, prefix)
+			if trimmed == "" {
+				trimmed = "/"
+			} else if !strings.HasPrefix(trimmed, "/") {
+				trimmed = "/" + trimmed
+			}
+			req.URL.Path = trimmed
+			if raw := req.URL.RawPath; raw != "" && strings.HasPrefix(raw, prefix) {
+				trimmedRaw := strings.TrimPrefix(raw, prefix)
+				if trimmedRaw == "" {
+					trimmedRaw = "/"
+				} else if !strings.HasPrefix(trimmedRaw, "/") {
+					trimmedRaw = "/" + trimmedRaw
+				}
+				req.URL.RawPath = trimmedRaw
+			}
+		}
+	}
+	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+		http.Error(rw, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
+	}
+
+	headers := make(map[string]string, len(rt.Headers))
+	for k, v := range rt.Headers {
+		headers[textproto.CanonicalMIMEHeaderKey(k)] = v
+	}
+
+	return &routeHandler{
+		pathPrefix: prefix,
+		headers:    headers,
+		proxy:      proxy,
+		strip:      strip,
+	}, nil
+}
+
+func (r *routeHandler) match(req *http.Request) bool {
+	if r.pathPrefix != "" && !strings.HasPrefix(req.URL.Path, r.pathPrefix) {
+		return false
+	}
+	if len(r.headers) == 0 {
+		return true
+	}
+	for key, value := range r.headers {
+		if req.Header.Get(key) != value {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *routeHandler) serve(w http.ResponseWriter, req *http.Request) {
+	r.proxy.ServeHTTP(w, req)
+}
+
+type assetHandler struct {
+	directory string
+	index     string
+}
+
+func (a *assetHandler) serve(w http.ResponseWriter, r *http.Request) bool {
+	if a.directory == "" {
+		return false
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+
+	cleaned := filepath.Clean(r.URL.Path)
+	if strings.Contains(cleaned, "..") {
+		http.NotFound(w, r)
+		return true
+	}
+
+	rel := strings.TrimPrefix(cleaned, "/")
+	rel = strings.TrimPrefix(rel, string(os.PathSeparator))
+	target := filepath.Join(a.directory, filepath.FromSlash(rel))
+	if info, err := os.Stat(target); err == nil && info.Mode().IsRegular() {
+		http.ServeFile(w, r, target)
+		return true
+	}
+
+	if a.index != "" {
+		if info, err := os.Stat(a.index); err == nil && info.Mode().IsRegular() {
+			http.ServeFile(w, r, a.index)
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -91,6 +91,10 @@ type StartSpec struct {
 	// primarily used by existing runtimes that need access to additional
 	// configuration that has not yet been promoted onto StartSpec.
 	Service *stack.Service
+
+	// Proxy carries the stack-level proxy configuration when the proxy runtime
+	// is requested.
+	Proxy *stack.Proxy
 }
 
 // Volume describes a bind mount exposed to the launched instance.

--- a/internal/stack/types.go
+++ b/internal/stack/types.go
@@ -7,6 +7,9 @@ type (
 	StackFile     = config.Stack
 	StackMeta     = config.StackMeta
 	Defaults      = config.Defaults
+	Proxy         = config.ProxySpec
+	ProxyRoute    = config.ProxyRoute
+	ProxyAssets   = config.ProxyAssetSpec
 	Service       = config.ServiceSpec
 	ServiceMap    = map[string]*Service
 	Dependency    = config.DepEdge


### PR DESCRIPTION
## Summary
- detect stack-level proxy configuration and synthesize a proxy node when building the engine DAG
- pass proxy specifications through the orchestrator and supervisor into a new in-process proxy runtime
- register the proxy runtime in the CLI and cover header/path routing with an integration test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5b84b7c088325bbdf63344432c1ff