### PR TITLE
Add Podman runtime support to config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Key behaviors:
 
 - `dependsOn.require` controls whether Orco waits for dependencies to start, exist, or reach readiness.
 - Probes support HTTP, TCP, command, and log checks, and an optional `expression` enables simple `OR` combinations.
-- `runtime` can be either `docker` or `process`, enabling mixed workloads.
+- `runtime` can be `docker`, `podman`, or `process`, enabling mixed workloads.
 - `update.strategy: canary` rolls updates out to a single replica and waits for `orco promote <service>` (or `update.promoteAfter`) before continuing.
 
 ## Engine design

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -243,8 +243,11 @@ func (s *Stack) ApplyDefaults() error {
 		if svc.Replicas == 0 {
 			svc.Replicas = 1
 		}
+		svc.Runtime = strings.TrimSpace(svc.Runtime)
 		if svc.Runtime == "" {
 			svc.Runtime = "docker"
+		} else {
+			svc.Runtime = strings.ToLower(svc.Runtime)
 		}
 		if svc.RestartPolicy == nil && s.Defaults.Restart != nil {
 			svc.RestartPolicy = s.Defaults.Restart.Clone()
@@ -336,10 +339,10 @@ func (s *Stack) Validate() error {
 		if svc.Runtime == "" {
 			return fmt.Errorf("%s: is required", serviceField(name, "runtime"))
 		}
-		if svc.Runtime != "docker" && svc.Runtime != "process" {
-			return fmt.Errorf("%s: unsupported runtime %q (supported values: docker, process)", serviceField(name, "runtime"), svc.Runtime)
+		if svc.Runtime != "docker" && svc.Runtime != "podman" && svc.Runtime != "process" {
+			return fmt.Errorf("%s: unsupported runtime %q (supported values: docker, podman, process)", serviceField(name, "runtime"), svc.Runtime)
 		}
-		if svc.Runtime == "docker" {
+		if svc.Runtime == "docker" || svc.Runtime == "podman" {
 			if strings.TrimSpace(svc.Image) == "" {
 				return fmt.Errorf("%s: is required", serviceField(name, "image"))
 			}

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -251,6 +251,48 @@ func TestStackValidateLoggingConstraints(t *testing.T) {
 	}
 }
 
+func TestStackValidateAllowsPodmanRuntime(t *testing.T) {
+	stack := &Stack{
+		Version: "0.1",
+		Stack:   StackMeta{Name: "demo"},
+		Services: map[string]*ServiceSpec{
+			"api": {
+				Runtime:  "podman",
+				Image:    "ghcr.io/demo/api:latest",
+				Replicas: 1,
+				Health: &ProbeSpec{
+					TCP: &TCPProbeSpec{Address: "localhost:8080"},
+				},
+			},
+		},
+	}
+
+	if err := stack.Validate(); err != nil {
+		t.Fatalf("stack.Validate returned error: %v", err)
+	}
+}
+
+func TestStackValidatePodmanRequiresImage(t *testing.T) {
+	stack := &Stack{
+		Version: "0.1",
+		Stack:   StackMeta{Name: "demo"},
+		Services: map[string]*ServiceSpec{
+			"api": {
+				Runtime:  "podman",
+				Replicas: 1,
+				Health: &ProbeSpec{
+					TCP: &TCPProbeSpec{Address: "localhost:8080"},
+				},
+			},
+		},
+	}
+
+	err := stack.Validate()
+	if err == nil || !strings.Contains(err.Error(), "services.api.image") {
+		t.Fatalf("expected image error, got %v", err)
+	}
+}
+
 func int64Ptr(v int64) *int64 {
 	return &v
 }


### PR DESCRIPTION
## Summary
- normalize service runtimes during defaulting and allow podman as a supported container backend
- add podman-specific config loader and validation tests covering success and missing image scenarios
- document podman alongside docker and process in runtime guidance

## Testing
- go test ./... *(fails: TestSupervisorMaxRetriesEmitsFailed)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bf625db48325bd9d37ea13c45909