### PR TITLE
Add runtime registry helper

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,9 +16,9 @@ import (
 	"github.com/Paintersrp/orco/internal/engine"
 	"github.com/Paintersrp/orco/internal/logmux"
 	"github.com/Paintersrp/orco/internal/runtime"
-	"github.com/Paintersrp/orco/internal/runtime/docker"
-	"github.com/Paintersrp/orco/internal/runtime/process"
-	proxyruntime "github.com/Paintersrp/orco/internal/runtime/proxy"
+	_ "github.com/Paintersrp/orco/internal/runtime/docker"
+	_ "github.com/Paintersrp/orco/internal/runtime/process"
+	_ "github.com/Paintersrp/orco/internal/runtime/proxy"
 	"github.com/Paintersrp/orco/internal/stack"
 )
 
@@ -151,11 +151,7 @@ func (c *context) applyStackLogRetention(doc *cliutil.StackDocument) {
 
 func (c *context) getOrchestrator() *engine.Orchestrator {
 	if c.orchestrator == nil {
-		c.orchestrator = engine.NewOrchestrator(runtime.Registry{
-			"docker":                 docker.New(),
-			"process":                process.New(),
-			proxyruntime.RuntimeName: proxyruntime.New(),
-		})
+		c.orchestrator = engine.NewOrchestrator(runtime.NewRegistry())
 	}
 	return c.orchestrator
 }

--- a/internal/runtime/docker/docker.go
+++ b/internal/runtime/docker/docker.go
@@ -38,6 +38,11 @@ func New() runtime.Runtime {
 	return &runtimeImpl{}
 }
 
+func init() {
+	runtime.Register("docker", New)
+	runtime.Register("podman", New)
+}
+
 func (r *runtimeImpl) getClient() (*client.Client, error) {
 	r.clientOnce.Do(func() {
 		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())

--- a/internal/runtime/process/process.go
+++ b/internal/runtime/process/process.go
@@ -24,6 +24,10 @@ func New() runtime.Runtime {
 	return &runtimeImpl{}
 }
 
+func init() {
+	runtime.Register("process", New)
+}
+
 func (r *runtimeImpl) Start(ctx context.Context, spec runtime.StartSpec) (runtime.Handle, error) {
 	if len(spec.Command) == 0 {
 		return nil, fmt.Errorf("process runtime for service %s requires a command", spec.Name)

--- a/internal/runtime/proxy/proxy.go
+++ b/internal/runtime/proxy/proxy.go
@@ -35,6 +35,10 @@ func New() runtime.Runtime {
 	return &runtimeImpl{}
 }
 
+func init() {
+	runtime.Register(RuntimeName, New)
+}
+
 type runtimeImpl struct{}
 
 // Start launches the proxy server according to the supplied specification.

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -1,0 +1,52 @@
+package runtime
+
+import "sync"
+
+// Factory constructs a runtime instance.
+type Factory func() Runtime
+
+type factoryEntry struct {
+	name    string
+	factory Factory
+}
+
+var (
+	registryMu       sync.RWMutex
+	builtinFactories []factoryEntry
+)
+
+// Register associates the provided factory with the runtime name. When multiple
+// factories register the same name the most recent registration wins.
+func Register(name string, factory Factory) {
+	if name == "" {
+		panic("runtime.Register: name must not be empty")
+	}
+	if factory == nil {
+		panic("runtime.Register: factory must not be nil")
+	}
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	for i, entry := range builtinFactories {
+		if entry.name == name {
+			builtinFactories[i].factory = factory
+			return
+		}
+	}
+
+	builtinFactories = append(builtinFactories, factoryEntry{name: name, factory: factory})
+}
+
+// NewRegistry constructs the default runtime registry containing all registered
+// runtime adapters.
+func NewRegistry() Registry {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	reg := make(Registry, len(builtinFactories))
+	for _, entry := range builtinFactories {
+		reg[entry.name] = entry.factory()
+	}
+	return reg
+}

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -1,0 +1,20 @@
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/Paintersrp/orco/internal/runtime"
+	_ "github.com/Paintersrp/orco/internal/runtime/docker"
+	_ "github.com/Paintersrp/orco/internal/runtime/process"
+	_ "github.com/Paintersrp/orco/internal/runtime/proxy"
+)
+
+func TestNewRegistryContainsBuiltInRuntimes(t *testing.T) {
+	reg := runtime.NewRegistry()
+
+	for _, key := range []string{"docker", "podman", "process", "proxy"} {
+		if _, ok := reg[key]; !ok {
+			t.Fatalf("expected registry to contain %q runtime", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a runtime registry helper that registers the built-in adapters
- load Docker, Podman, process, and proxy runtimes through the shared registry in the CLI
- cover the registry helper with tests to ensure all default runtimes are exposed

## Testing
- go test ./internal/runtime...


------
https://chatgpt.com/codex/tasks/task_e_68e5c2037d2083259311f819571681da