### PR TITLE
Add HTTP control API server and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ These commands currently validate the stack definition, construct the dependency
 
 The `examples/canary-stack.yaml` manifest demonstrates configuring a canary update strategy with optional automatic promotion.
 
+### Control API
+
+Orco ships with an optional HTTP control plane that exposes orchestrator status and lifecycle operations. The API is disabled by default and can be enabled either by exporting `ORCO_ENABLE_API=true` or by passing `--api` on the `serve` command. The API binds to `127.0.0.1:7663` unless an alternate address is provided.
+
+```
+ORCO_ENABLE_API=true ./orco serve
+# or explicitly select an address
+./orco serve --api 127.0.0.1:9000
+```
+
+When enabled, the following endpoints are available:
+
+| Method | Path                          | Description |
+| ------ | ----------------------------- | ----------- |
+| `GET`  | `/api/v1/status`              | Returns a JSON snapshot of the active stack, including per-service readiness, restart counts, replica health, resource hints, and the most recent probe/restart events. |
+| `POST` | `/api/v1/restart/{service}`   | Executes a rolling restart of the named service and waits for readiness before returning a summary payload. |
+| `POST` | `/api/v1/apply`               | Reconciles stack changes and responds with the computed diff plus the latest status snapshot. |
+
+All error responses use the structure `{ "code": string, "message": string, "details": object }` to support machine parsing of failure conditions.
+
 ## Problem statement
 
 Traditional tooling such as `docker-compose` is optimized for "bring up these services" but leaves orchestration concerns to operators. This leads to awkward limitations:

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1,0 +1,250 @@
+package httpapi
+
+import (
+	stdcontext "context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/api"
+)
+
+const (
+	defaultAddr            = "127.0.0.1:7663"
+	defaultReadHeader      = 5 * time.Second
+	defaultShutdownTimeout = 5 * time.Second
+)
+
+// Config controls construction of the API server.
+type Config struct {
+	Addr              string
+	Controller        api.Controller
+	Listener          net.Listener
+	ReadHeaderTimeout time.Duration
+	ShutdownTimeout   time.Duration
+}
+
+// Server wraps an http.Server exposing orchestration controls.
+type Server struct {
+	ctrl            api.Controller
+	srv             *http.Server
+	listener        net.Listener
+	shutdownTimeout time.Duration
+}
+
+// NewServer constructs a Server with sane defaults.
+func NewServer(cfg Config) (*Server, error) {
+	if cfg.Controller == nil {
+		return nil, fmt.Errorf("controller is required")
+	}
+	addr := normalizeAddr(cfg.Addr)
+	mux := http.NewServeMux()
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+	}
+	if srv.ReadHeaderTimeout == 0 {
+		srv.ReadHeaderTimeout = defaultReadHeader
+	}
+	server := &Server{
+		ctrl:            cfg.Controller,
+		srv:             srv,
+		listener:        cfg.Listener,
+		shutdownTimeout: cfg.ShutdownTimeout,
+	}
+	if server.shutdownTimeout == 0 {
+		server.shutdownTimeout = defaultShutdownTimeout
+	}
+	server.registerRoutes(mux)
+	return server, nil
+}
+
+// Run starts serving until the provided context is cancelled.
+func (s *Server) Run(ctx stdcontext.Context) error {
+	if ctx == nil {
+		ctx = stdcontext.Background()
+	}
+	errCh := make(chan error, 1)
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), s.shutdownTimeout)
+			defer cancel()
+			_ = s.srv.Shutdown(shutdownCtx)
+		case <-stop:
+		}
+	}()
+
+	go func() {
+		var err error
+		if s.listener != nil {
+			err = s.srv.Serve(s.listener)
+		} else {
+			err = s.srv.ListenAndServe()
+		}
+		errCh <- err
+	}()
+
+	err := <-errCh
+	close(stop)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// Addr returns the listen address.
+func (s *Server) Addr() string {
+	if s.listener != nil {
+		return s.listener.Addr().String()
+	}
+	return s.srv.Addr
+}
+
+func (s *Server) registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/v1/status", s.handleStatus)
+	mux.HandleFunc("/api/v1/restart/", s.handleRestart)
+	mux.HandleFunc("/api/v1/apply", s.handleApply)
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	result, err := s.ctrl.Status(r.Context())
+	if err != nil {
+		s.writeError(w, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.methodNotAllowed(w, http.MethodPost)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/api/v1/restart/")
+	name = strings.TrimSpace(name)
+	if name == "" || strings.Contains(name, "/") {
+		s.writeErrorWithDetails(w, fmt.Errorf("%w: invalid service path", api.ErrUnknownService), map[string]any{"service": name})
+		return
+	}
+	result, err := s.ctrl.RestartService(r.Context(), name)
+	if err != nil {
+		s.writeErrorWithDetails(w, err, map[string]any{"service": name})
+		return
+	}
+	payload := map[string]any{
+		"restart": result,
+	}
+	s.writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.methodNotAllowed(w, http.MethodPost)
+		return
+	}
+	result, err := s.ctrl.Apply(r.Context())
+	if err != nil {
+		s.writeError(w, err)
+		return
+	}
+	payload := map[string]any{
+		"apply": result,
+	}
+	if status, statusErr := s.ctrl.Status(r.Context()); statusErr == nil {
+		payload["status"] = status
+	}
+	s.writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *Server) methodNotAllowed(w http.ResponseWriter, method string) {
+	w.Header().Set("Allow", method)
+	s.writeJSON(w, http.StatusMethodNotAllowed, errorBody{
+		Code:    "method_not_allowed",
+		Message: fmt.Sprintf("method %s not allowed", method),
+	})
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	if payload == nil {
+		return
+	}
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+type errorBody struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message"`
+	Details interface{} `json:"details"`
+}
+
+func (s *Server) writeError(w http.ResponseWriter, err error) {
+	s.writeErrorWithDetails(w, err, nil)
+}
+
+func (s *Server) writeErrorWithDetails(w http.ResponseWriter, err error, extra map[string]any) {
+	status, code := classifyError(err)
+	details := map[string]any{
+		"timestamp": time.Now().UTC(),
+	}
+	for k, v := range extra {
+		details[k] = v
+	}
+	body := errorBody{
+		Code:    code,
+		Message: err.Error(),
+		Details: details,
+	}
+	s.writeJSON(w, status, body)
+}
+
+func classifyError(err error) (int, string) {
+	switch {
+	case errors.Is(err, stdcontext.Canceled):
+		return 499, "context_canceled"
+	case errors.Is(err, api.ErrUnknownService):
+		return http.StatusNotFound, "unknown_service"
+	case errors.Is(err, api.ErrNoActiveDeployment):
+		return http.StatusConflict, "no_active_deployment"
+	case errors.Is(err, api.ErrStackMismatch):
+		return http.StatusConflict, "stack_mismatch"
+	case errors.Is(err, api.ErrServiceNotRunning):
+		return http.StatusConflict, "service_not_running"
+	case errors.Is(err, api.ErrNoStoredStackSpec):
+		return http.StatusConflict, "missing_stack_spec"
+	case errors.Is(err, api.ErrUnsupportedChange):
+		return http.StatusBadRequest, "unsupported_change"
+	case errors.Is(err, api.ErrReadinessTimeout):
+		return http.StatusGatewayTimeout, "readiness_timeout"
+	default:
+		return http.StatusInternalServerError, "internal_error"
+	}
+}
+
+func normalizeAddr(addr string) string {
+	if strings.TrimSpace(addr) == "" {
+		return defaultAddr
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		// If parsing failed, trust caller.
+		return addr
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	stdcontext "context"
+	"errors"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/engine"
+)
+
+var (
+	ErrNoActiveDeployment = errors.New("no active deployment")
+	ErrStackMismatch      = errors.New("stack mismatch")
+	ErrUnknownService     = errors.New("unknown service")
+	ErrServiceNotRunning  = errors.New("service not running")
+	ErrNoStoredStackSpec  = errors.New("missing stack specification")
+	ErrUnsupportedChange  = errors.New("unsupported change")
+	ErrReadinessTimeout   = errors.New("service readiness timeout")
+)
+
+// ResourceHint captures formatted CPU and memory hints for API responses.
+type ResourceHint struct {
+	CPU    string `json:"cpu"`
+	Memory string `json:"memory"`
+}
+
+// ServiceTransition mirrors cli.ServiceTransition for API consumers.
+type ServiceTransition struct {
+	Timestamp time.Time        `json:"timestamp"`
+	Type      engine.EventType `json:"type"`
+	Reason    string           `json:"reason"`
+	Message   string           `json:"message"`
+}
+
+// ServiceReport describes the runtime state for a single service.
+type ServiceReport struct {
+	Name          string              `json:"name"`
+	State         engine.EventType    `json:"state"`
+	Ready         bool                `json:"ready"`
+	Restarts      int                 `json:"restarts"`
+	Replicas      int                 `json:"replicas"`
+	ReadyReplicas int                 `json:"ready_replicas"`
+	Message       string              `json:"message"`
+	FirstSeen     time.Time           `json:"first_seen"`
+	LastEvent     time.Time           `json:"last_event"`
+	Resources     ResourceHint        `json:"resources"`
+	History       []ServiceTransition `json:"history"`
+	LastReason    string              `json:"last_reason"`
+}
+
+// StatusReport aggregates stack-wide status information.
+type StatusReport struct {
+	Stack       string                   `json:"stack"`
+	Version     string                   `json:"version"`
+	GeneratedAt time.Time                `json:"generated_at"`
+	Services    map[string]ServiceReport `json:"services"`
+}
+
+// RestartResult captures the outcome of a restart operation.
+type RestartResult struct {
+	Service       string    `json:"service"`
+	Replicas      int       `json:"replicas"`
+	ReadyReplicas int       `json:"ready_replicas"`
+	CompletedAt   time.Time `json:"completed_at"`
+	Restarts      int       `json:"restarts"`
+}
+
+// ApplyResult captures the outcome of an apply operation.
+type ApplyResult struct {
+	Diff     string                   `json:"diff"`
+	Updated  []string                 `json:"updated"`
+	Stack    string                   `json:"stack"`
+	Snapshot map[string]ServiceReport `json:"snapshot"`
+}
+
+// Controller exposes orchestrator operations required by control servers.
+type Controller interface {
+	Status(stdcontext.Context) (*StatusReport, error)
+	RestartService(stdcontext.Context, string) (*RestartResult, error)
+	Apply(stdcontext.Context) (*ApplyResult, error)
+}

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	stdcontext "context"
+	"fmt"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/api"
+)
+
+const defaultHistoryDepth = 10
+
+// ControlAPI exposes orchestrator operations for the HTTP control plane.
+type ControlAPI struct {
+	ctx *context
+}
+
+// NewControlAPI constructs a ControlAPI wrapper around the shared CLI context.
+func NewControlAPI(ctx *context) *ControlAPI {
+	if ctx == nil {
+		return nil
+	}
+	return &ControlAPI{ctx: ctx}
+}
+
+// Status returns the current orchestrator status snapshot.
+func (apiCtrl *ControlAPI) Status(ctx stdcontext.Context) (*api.StatusReport, error) {
+	if apiCtrl == nil || apiCtrl.ctx == nil {
+		return nil, fmt.Errorf("%w", api.ErrNoActiveDeployment)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
+	if apiCtrl.ctx.currentDeployment() == nil {
+		return nil, fmt.Errorf("%w for status", api.ErrNoActiveDeployment)
+	}
+	tracker := apiCtrl.ctx.statusTracker()
+	snapshot := tracker.Snapshot()
+	services := make(map[string]api.ServiceReport, len(snapshot))
+	for name, status := range snapshot {
+		history := tracker.History(name, defaultHistoryDepth)
+		apiHistory := make([]api.ServiceTransition, 0, len(history))
+		for _, entry := range history {
+			apiHistory = append(apiHistory, api.ServiceTransition{
+				Timestamp: entry.Timestamp,
+				Type:      entry.Type,
+				Reason:    entry.Reason,
+				Message:   entry.Message,
+			})
+		}
+		lastReason := ""
+		if len(apiHistory) > 0 {
+			lastReason = apiHistory[len(apiHistory)-1].Reason
+		}
+		services[name] = api.ServiceReport{
+			Name:          status.Name,
+			State:         status.State,
+			Ready:         status.Ready,
+			Restarts:      status.Restarts,
+			Replicas:      status.Replicas,
+			ReadyReplicas: status.ReadyReplicas,
+			Message:       status.Message,
+			FirstSeen:     status.FirstSeen,
+			LastEvent:     status.LastEvent,
+			Resources: api.ResourceHint{
+				CPU:    status.Resources.CPU,
+				Memory: status.Resources.Memory,
+			},
+			History:    apiHistory,
+			LastReason: lastReason,
+		}
+	}
+
+	_, stackName := apiCtrl.ctx.currentDeploymentInfo()
+	doc, err := apiCtrl.ctx.loadStack()
+	var version string
+	if err == nil && doc != nil && doc.File != nil {
+		if stackName == "" {
+			stackName = doc.File.Stack.Name
+		}
+		version = doc.File.Version
+	}
+
+	report := &api.StatusReport{
+		Stack:       stackName,
+		Version:     version,
+		GeneratedAt: time.Now(),
+		Services:    services,
+	}
+	return report, nil
+}
+
+// RestartService executes a rolling restart for the provided service using the orchestrator managed by the CLI context.
+func (apiCtrl *ControlAPI) RestartService(ctx stdcontext.Context, service string) (*api.RestartResult, error) {
+	return restartService(ctx, apiCtrl.ctx, service, nil)
+}
+
+// Apply reconciles stack changes using the orchestrator managed by the CLI context.
+func (apiCtrl *ControlAPI) Apply(ctx stdcontext.Context) (*api.ApplyResult, error) {
+	return runApply(ctx, apiCtrl.ctx, nil)
+}
+
+// Ensure interface compliance at compile time.
+var _ api.Controller = (*ControlAPI)(nil)

--- a/internal/cli/api_server_integration_test.go
+++ b/internal/cli/api_server_integration_test.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	stdcontext "context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/api"
+	apihttp "github.com/Paintersrp/orco/internal/api/http"
+	"github.com/Paintersrp/orco/internal/engine"
+	"github.com/Paintersrp/orco/internal/runtime"
+	"github.com/Paintersrp/orco/internal/stack"
+)
+
+func TestControlAPIStatusRestartAndApply(t *testing.T) {
+	t.Parallel()
+
+	rt := newMockRuntime()
+	stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  api:
+    runtime: process
+    replicas: 1
+    command: ["sleep", "0"]
+`)
+
+	ctx := &context{
+		stackFile:    &stackPath,
+		orchestrator: engine.NewOrchestrator(runtime.Registry{"process": rt}),
+	}
+
+	doc, err := ctx.loadStack()
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+
+	events := make(chan engine.Event, 256)
+	trackedEvents, release := ctx.trackEvents(doc.File.Stack.Name, events, cap(events))
+	defer release()
+
+	drainDone := make(chan struct{})
+	go func() {
+		for range trackedEvents {
+		}
+		close(drainDone)
+	}()
+
+	runCtx, runCancel := stdcontext.WithCancel(stdcontext.Background())
+	defer runCancel()
+
+	deployment, err := ctx.getOrchestrator().Up(runCtx, doc.File, doc.Graph, events)
+	if err != nil {
+		t.Fatalf("orchestrator up: %v", err)
+	}
+	ctx.setDeployment(deployment, doc.File.Stack.Name, stack.CloneServiceMap(doc.File.Services))
+	defer func() {
+		stopCtx, cancel := stdcontext.WithTimeout(stdcontext.Background(), time.Second)
+		_ = deployment.Stop(stopCtx, events)
+		cancel()
+		ctx.clearDeployment(deployment)
+		close(events)
+		<-drainDone
+	}()
+
+	waitForServiceReady(t, ctx.statusTracker(), "api", 1)
+
+	control := NewControlAPI(ctx)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server, err := apihttp.NewServer(apihttp.Config{Controller: control, Listener: listener})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	serverCtx, serverCancel := stdcontext.WithCancel(stdcontext.Background())
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- server.Run(serverCtx)
+	}()
+	t.Cleanup(func() {
+		serverCancel()
+		if err := <-serverErr; err != nil {
+			t.Fatalf("server error: %v", err)
+		}
+	})
+
+	baseURL := fmt.Sprintf("http://%s", server.Addr())
+
+	statusResp, err := http.Get(baseURL + "/api/v1/status")
+	if err != nil {
+		t.Fatalf("status request: %v", err)
+	}
+	defer statusResp.Body.Close()
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", statusResp.StatusCode)
+	}
+
+	var statusBody api.StatusReport
+	if err := json.NewDecoder(statusResp.Body).Decode(&statusBody); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if statusBody.Stack != doc.File.Stack.Name {
+		t.Fatalf("unexpected stack name: %s", statusBody.Stack)
+	}
+	apiService, ok := statusBody.Services["api"]
+	if !ok {
+		t.Fatalf("status missing api service: %+v", statusBody.Services)
+	}
+	if !apiService.Ready {
+		t.Fatalf("expected api ready, got %+v", apiService)
+	}
+	if len(apiService.History) == 0 {
+		t.Fatalf("expected history entries, got none")
+	}
+
+	restartResp, err := http.Post(baseURL+"/api/v1/restart/api", "application/json", nil)
+	if err != nil {
+		t.Fatalf("restart request: %v", err)
+	}
+	defer restartResp.Body.Close()
+	if restartResp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected restart status: %d", restartResp.StatusCode)
+	}
+	var restartBody struct {
+		Restart api.RestartResult `json:"restart"`
+	}
+	if err := json.NewDecoder(restartResp.Body).Decode(&restartBody); err != nil {
+		t.Fatalf("decode restart body: %v", err)
+	}
+	if restartBody.Restart.Service != "api" {
+		t.Fatalf("unexpected service in restart result: %+v", restartBody.Restart)
+	}
+
+	if restartBody.Restart.Replicas != 1 || restartBody.Restart.ReadyReplicas != 1 {
+		t.Fatalf("unexpected replica counts in restart result: %+v", restartBody.Restart)
+	}
+	if restartBody.Restart.CompletedAt.IsZero() {
+		t.Fatalf("expected completion timestamp in restart result")
+	}
+
+	history := ctx.statusTracker().History("api", 5)
+	var sawRestart bool
+	for _, entry := range history {
+		if entry.Reason == engine.ReasonRestart {
+			sawRestart = true
+			break
+		}
+	}
+	if !sawRestart {
+		t.Fatalf("expected restart reason in history, got %+v", history)
+	}
+
+	applyResp, err := http.Post(baseURL+"/api/v1/apply", "application/json", nil)
+	if err != nil {
+		t.Fatalf("apply request: %v", err)
+	}
+	defer applyResp.Body.Close()
+	if applyResp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected apply status: %d", applyResp.StatusCode)
+	}
+	var applyBody struct {
+		Apply  api.ApplyResult   `json:"apply"`
+		Status *api.StatusReport `json:"status"`
+	}
+	if err := json.NewDecoder(applyResp.Body).Decode(&applyBody); err != nil {
+		t.Fatalf("decode apply body: %v", err)
+	}
+	if applyBody.Apply.Stack != doc.File.Stack.Name {
+		t.Fatalf("unexpected stack in apply result: %+v", applyBody.Apply)
+	}
+	if applyBody.Apply.Diff != "No changes detected." {
+		t.Fatalf("unexpected apply diff: %q", applyBody.Apply.Diff)
+	}
+	if applyBody.Status == nil {
+		t.Fatalf("expected status snapshot in apply response")
+	}
+	if svc, ok := applyBody.Status.Services["api"]; !ok || !svc.Ready {
+		t.Fatalf("expected ready api service in apply snapshot, got %+v", applyBody.Status.Services)
+	}
+}
+
+func waitForServiceReady(t *testing.T, tracker *statusTracker, service string, replicas int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snap := tracker.Snapshot()[service]
+		if snap.Ready && snap.ReadyReplicas >= replicas {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("service %s did not report ready", service)
+}

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
-	"errors"
+	stdcontext "context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Paintersrp/orco/internal/api"
 )
 
 func newRestartCmd(ctx *context) *cobra.Command {
@@ -14,79 +17,108 @@ func newRestartCmd(ctx *context) *cobra.Command {
 		Short: "Plan a rolling restart of the specified service",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			doc, err := ctx.loadStack()
-			if err != nil {
-				return err
-			}
-			svcName := args[0]
-			svc, ok := doc.File.Services[svcName]
-			if !ok {
-				return fmt.Errorf("unknown service %s", svcName)
-			}
-			strategy := "rolling"
-			if svc.Update != nil && svc.Update.Strategy != "" {
-				strategy = svc.Update.Strategy
-			}
-			if strategy != "rolling" && strategy != "canary" {
-				return fmt.Errorf("unsupported update strategy %q for service %s", strategy, svcName)
-			}
-
-			dep, stackName := ctx.currentDeploymentInfo()
-			if dep == nil {
-				return errors.New("no active deployment to restart")
-			}
-			if stackName != "" && stackName != doc.File.Stack.Name {
-				return fmt.Errorf("active deployment %s does not match stack %s", stackName, doc.File.Stack.Name)
-			}
-
-			service, ok := dep.Service(svcName)
-			if !ok {
-				return fmt.Errorf("service %s is not currently running", svcName)
-			}
-
-			replicas := service.Replicas()
-			if replicas < 1 {
-				replicas = 1
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Rolling restart of %s (%d replicas)\n", svcName, replicas)
-
-			tracker := ctx.statusTracker()
-
-			for i := 0; i < replicas; i++ {
-				fmt.Fprintf(cmd.OutOrStdout(), "Restarting %s replica %d/%d...\n", svcName, i+1, replicas)
-				if err := service.RestartReplica(cmd.Context(), i); err != nil {
-					return fmt.Errorf("restart %s replica %d: %w", svcName, i, err)
-				}
-
-				var status ServiceStatus
-				deadline := time.Now().Add(5 * time.Second)
-				for {
-					snapshot := tracker.Snapshot()
-					status = snapshot[svcName]
-					if status.Ready && status.ReadyReplicas >= replicas {
-						break
-					}
-					if time.Now().After(deadline) {
-						return fmt.Errorf("timed out waiting for %s readiness after restarting replica %d", svcName, i)
-					}
-					select {
-					case <-cmd.Context().Done():
-						return cmd.Context().Err()
-					case <-time.After(50 * time.Millisecond):
-					}
-				}
-
-				readyReplicas := status.ReadyReplicas
-				if readyReplicas > replicas {
-					readyReplicas = replicas
-				}
-				fmt.Fprintf(cmd.OutOrStdout(), "Replica %d/%d ready (service readiness: %d/%d, Ready)\n", i+1, replicas, readyReplicas, replicas)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Completed rolling restart of %s.\n", svcName)
-			return nil
+			_, err := restartService(cmd.Context(), ctx, args[0], cmd.OutOrStdout())
+			return err
 		},
 	}
 	return cmd
+}
+
+func restartService(ctx stdcontext.Context, cliCtx *context, svcName string, out io.Writer) (*api.RestartResult, error) {
+	doc, err := cliCtx.loadStack()
+	if err != nil {
+		return nil, err
+	}
+
+	svc, ok := doc.File.Services[svcName]
+	if !ok {
+		return nil, fmt.Errorf("%w %s", api.ErrUnknownService, svcName)
+	}
+	strategy := "rolling"
+	if svc.Update != nil && svc.Update.Strategy != "" {
+		strategy = svc.Update.Strategy
+	}
+	if strategy != "rolling" && strategy != "canary" {
+		return nil, fmt.Errorf("%w: unsupported update strategy %q for service %s", api.ErrUnsupportedChange, strategy, svcName)
+	}
+
+	dep, stackName := cliCtx.currentDeploymentInfo()
+	if dep == nil {
+		return nil, fmt.Errorf("%w to restart", api.ErrNoActiveDeployment)
+	}
+	if stackName != "" && stackName != doc.File.Stack.Name {
+		return nil, fmt.Errorf("%w: active deployment %s does not match stack %s", api.ErrStackMismatch, stackName, doc.File.Stack.Name)
+	}
+
+	service, ok := dep.Service(svcName)
+	if !ok {
+		return nil, fmt.Errorf("%w: service %s is not currently running", api.ErrServiceNotRunning, svcName)
+	}
+
+	replicas := service.Replicas()
+	if replicas < 1 {
+		replicas = 1
+	}
+
+	if out != nil {
+		fmt.Fprintf(out, "Rolling restart of %s (%d replicas)\n", svcName, replicas)
+	}
+
+	tracker := cliCtx.statusTracker()
+
+	for i := 0; i < replicas; i++ {
+		if out != nil {
+			fmt.Fprintf(out, "Restarting %s replica %d/%d...\n", svcName, i+1, replicas)
+		}
+		if err := service.RestartReplica(ctx, i); err != nil {
+			return nil, fmt.Errorf("restart %s replica %d: %w", svcName, i, err)
+		}
+
+		var status ServiceStatus
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			snapshot := tracker.Snapshot()
+			status = snapshot[svcName]
+			if status.Ready && status.ReadyReplicas >= replicas {
+				break
+			}
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("%w waiting for %s readiness after restarting replica %d", api.ErrReadinessTimeout, svcName, i)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+
+		readyReplicas := status.ReadyReplicas
+		if readyReplicas > replicas {
+			readyReplicas = replicas
+		}
+		if out != nil {
+			fmt.Fprintf(out, "Replica %d/%d ready (service readiness: %d/%d, Ready)\n", i+1, replicas, readyReplicas, replicas)
+		}
+	}
+
+	if out != nil {
+		fmt.Fprintf(out, "Completed rolling restart of %s.\n", svcName)
+	}
+
+	finalStatus := tracker.Snapshot()[svcName]
+	result := &api.RestartResult{
+		Service:       svcName,
+		Replicas:      replicas,
+		ReadyReplicas: min(finalStatus.ReadyReplicas, replicas),
+		CompletedAt:   time.Now(),
+		Restarts:      finalStatus.Restarts,
+	}
+	return result, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,7 @@ func newRootCommand() (*cobra.Command, *context) {
 	root.AddCommand(newApplyCmd(ctx))
 	root.AddCommand(newPromoteCmd(ctx))
 	root.AddCommand(newTuiCmd(ctx))
+	root.AddCommand(newServeCmd(ctx))
 	root.AddCommand(newConfigCmd())
 
 	root.SilenceUsage = true

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	stdcontext "context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	apihttp "github.com/Paintersrp/orco/internal/api/http"
+)
+
+func newServeCmd(ctx *context) *cobra.Command {
+	var apiAddr string
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Run services with the HTTP control API enabled",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			doc, err := ctx.loadStack()
+			if err != nil {
+				return err
+			}
+
+			enableAPI := apiEnabled()
+			if cmd.Flags().Changed("api") {
+				enableAPI = true
+			}
+			if !enableAPI {
+				fmt.Fprintln(cmd.OutOrStdout(), "HTTP API disabled; set ORCO_ENABLE_API=true or pass --api to enable.")
+			}
+
+			var hook func(stdcontext.Context) (func() error, error)
+			if enableAPI {
+				addr := apiAddr
+				control := NewControlAPI(ctx)
+				if control == nil {
+					return errors.New("control API unavailable")
+				}
+				hook = func(runCtx stdcontext.Context) (func() error, error) {
+					server, err := apihttp.NewServer(apihttp.Config{Addr: addr, Controller: control})
+					if err != nil {
+						return nil, err
+					}
+					serverCtx, cancel := stdcontext.WithCancel(runCtx)
+					errCh := make(chan error, 1)
+					go func() {
+						errCh <- server.Run(serverCtx)
+					}()
+					fmt.Fprintf(cmd.OutOrStdout(), "Control API listening on %s\n", server.Addr())
+					return func() error {
+						cancel()
+						err := <-errCh
+						if err != nil && !errors.Is(err, stdcontext.Canceled) && !errors.Is(err, http.ErrServerClosed) {
+							return err
+						}
+						return nil
+					}, nil
+				}
+			}
+
+			return runUpNonInteractiveWithHook(cmd, ctx, doc, hook)
+		},
+	}
+	cmd.Flags().StringVar(&apiAddr, "api", ":7663", "address for the HTTP control API (requires ORCO_ENABLE_API or explicit flag)")
+	return cmd
+}
+
+func apiEnabled() bool {
+	value := strings.TrimSpace(os.Getenv("ORCO_ENABLE_API"))
+	if value == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return false
+	}
+	return enabled
+}


### PR DESCRIPTION
## Summary
- add HTTP control server and API types for status, restart, and apply endpoints with structured errors
- expose shared orchestration helpers through a new ControlAPI and integrate the server behind the serve command
- document the control API and add an integration test covering status, restart, and apply flows

## Testing
- GOFLAGS="-tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper" go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e64a960b3883258c2f1b4f6c4edc5c