### PR TITLE
Guard controller APIs against nil inputs

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -40,6 +41,13 @@ type Server struct {
 func NewServer(cfg Config) (*Server, error) {
 	if cfg.Controller == nil {
 		return nil, fmt.Errorf("controller is required")
+	}
+	ctrlValue := reflect.ValueOf(cfg.Controller)
+	switch ctrlValue.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Interface, reflect.Ptr, reflect.Slice:
+		if ctrlValue.IsNil() {
+			return nil, fmt.Errorf("controller is required")
+		}
 	}
 	addr := normalizeAddr(cfg.Addr)
 	mux := http.NewServeMux()

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -1,0 +1,30 @@
+package httpapi
+
+import (
+	stdcontext "context"
+	"testing"
+
+	"github.com/Paintersrp/orco/internal/api"
+)
+
+type testController struct{}
+
+func (t *testController) Status(stdcontext.Context) (*api.StatusReport, error) {
+	return nil, nil
+}
+
+func (t *testController) RestartService(stdcontext.Context, string) (*api.RestartResult, error) {
+	return nil, nil
+}
+
+func (t *testController) Apply(stdcontext.Context) (*api.ApplyResult, error) {
+	return nil, nil
+}
+
+func TestNewServerRejectsTypedNilController(t *testing.T) {
+	var ctrl api.Controller = (*testController)(nil)
+	_, err := NewServer(Config{Controller: ctrl})
+	if err == nil {
+		t.Fatalf("expected error when controller is typed nil")
+	}
+}

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -96,11 +96,31 @@ func (apiCtrl *ControlAPI) Status(ctx stdcontext.Context) (*api.StatusReport, er
 
 // RestartService executes a rolling restart for the provided service using the orchestrator managed by the CLI context.
 func (apiCtrl *ControlAPI) RestartService(ctx stdcontext.Context, service string) (*api.RestartResult, error) {
+	if apiCtrl == nil || apiCtrl.ctx == nil {
+		return nil, fmt.Errorf("%w", api.ErrNoActiveDeployment)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
 	return restartService(ctx, apiCtrl.ctx, service, nil)
 }
 
 // Apply reconciles stack changes using the orchestrator managed by the CLI context.
 func (apiCtrl *ControlAPI) Apply(ctx stdcontext.Context) (*api.ApplyResult, error) {
+	if apiCtrl == nil || apiCtrl.ctx == nil {
+		return nil, fmt.Errorf("%w", api.ErrNoActiveDeployment)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
 	return runApply(ctx, apiCtrl.ctx, nil)
 }
 

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	stdcontext "context"
+	"errors"
+	"testing"
+
+	"github.com/Paintersrp/orco/internal/api"
+)
+
+func TestControlAPI_NilGuards(t *testing.T) {
+	var ctrl *ControlAPI
+
+	if _, err := ctrl.RestartService(stdcontext.Background(), "example"); !errors.Is(err, api.ErrNoActiveDeployment) {
+		t.Fatalf("expected ErrNoActiveDeployment for RestartService, got %v", err)
+	}
+
+	if _, err := ctrl.Apply(stdcontext.Background()); !errors.Is(err, api.ErrNoActiveDeployment) {
+		t.Fatalf("expected ErrNoActiveDeployment for Apply, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent the HTTP server from accepting typed-nil controllers by validating controller values
- add nil/context guards to CLI controller methods to match Status behaviour
- introduce regression tests covering typed-nil controllers and nil ControlAPI usage

## Testing
- go test ./internal/api/http -run TestNewServerRejectsTypedNilController -count=1
- go test ./internal/cli -run TestControlAPI_NilGuards -count=1 -v *(fails: missing system libraries such as gpgme/devmapper)*

------
https://chatgpt.com/codex/tasks/task_e_68e658f7b7f08325a0743b1e7f7535b7