### PR TITLE
Preserve explicit API listen hosts in normalizeAddr

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -251,7 +251,7 @@ func normalizeAddr(addr string) string {
 		// If parsing failed, trust caller.
 		return addr
 	}
-	if host == "" || host == "0.0.0.0" || host == "::" {
+	if host == "" {
 		host = "127.0.0.1"
 	}
 	return net.JoinHostPort(host, port)

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -44,9 +44,11 @@ func TestNormalizeAddr(t *testing.T) {
 
 	tests := map[string]string{
 		"":           defaultAddr,
-		"0.0.0.0:80": "127.0.0.1:80",
-		"[::]:80":    "127.0.0.1:80",
+		":80":        "127.0.0.1:80",
+		"0.0.0.0:80": "0.0.0.0:80",
+		"[::]:80":    "[::]:80",
 		"host:9000":  "host:9000",
+		"[::1]:443":  "[::1]:443",
 	}
 
 	for input, expected := range tests {


### PR DESCRIPTION
## Summary
- avoid forcing 127.0.0.1 when normalizeAddr receives an explicit host like 0.0.0.0 or ::
- expand TestNormalizeAddr expectations to cover new behavior and additional edge cases

## Testing
- go test ./internal/api/http -run TestNormalizeAddr


------
https://chatgpt.com/codex/tasks/task_e_68e662b829348325be7b21c2160b01e7