### PR TITLE
Switch probe latency metric to summary

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,10 +24,11 @@ var (
 		Help:      "Total number of restarts initiated for each service.",
 	}, []string{"service"})
 
-	probeLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "orco",
-		Name:      "probe_latency_seconds",
-		Help:      "Latency of readiness probe executions in seconds.",
+	probeLatency = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  "orco",
+		Name:       "probe_latency_seconds",
+		Help:       "Latency of readiness probe executions in seconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"service"})
 
 	buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
## Summary
- replace the readiness probe latency histogram with a Prometheus summary configured with common quantiles
- update metrics and HTTP server tests to observe probe latency and assert the summary’s exported series

## Testing
- go test ./... *(fails: missing system libraries for gpgme, devmapper, and btrfs headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e672e16d448325a6632239cdc5097a