### PR TITLE
Add metrics instrumentation for update outcomes

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -147,6 +147,7 @@ func applyUpdates(ctx stdcontext.Context, cliCtx *context, stackName string, dep
 				ticker.Stop()
 				if updateErr != nil {
 					metrics.SetServiceReady(name, false)
+					metrics.ObserveUpdateOutcome(name, "failure")
 					rollbackErr := rollbackUpdates(ctx, dep, oldSpec, updated)
 					cliCtx.setDeployment(dep, stackName, oldSpec)
 					if rollbackErr != nil {
@@ -174,6 +175,7 @@ func applyUpdates(ctx stdcontext.Context, cliCtx *context, stackName string, dep
 				}
 			case <-ctx.Done():
 				ticker.Stop()
+				metrics.ObserveUpdateOutcome(name, "failure")
 				return ctx.Err()
 			}
 		}
@@ -213,6 +215,7 @@ func applyUpdates(ctx stdcontext.Context, cliCtx *context, stackName string, dep
 			state = "Ready"
 		}
 		metrics.SetServiceReady(name, status.Ready)
+		metrics.ObserveUpdateOutcome(name, "success")
 		if out != nil {
 			fmt.Fprintf(out, "Service %s ready (%d/%d replicas, %s)\n", name, ready, replicas, state)
 		}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -20,6 +20,8 @@ func TestRegistryExposesMetrics(t *testing.T) {
 	metrics.SetServiceReady(service, true)
 	metrics.AddServiceRestarts(service, 2)
 	metrics.ObserveProbeLatency(service, 150*time.Millisecond)
+	metrics.ObserveUpdateOutcome(service, "success")
+	metrics.ObserveUpdateOutcome(service, "failure")
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -54,6 +56,14 @@ func TestRegistryExposesMetrics(t *testing.T) {
 	latencyCountLine := fmt.Sprintf("orco_probe_latency_seconds_count{service=\"%s\"} 1", service)
 	if !strings.Contains(body, latencyCountLine) {
 		t.Fatalf("expected latency count metric line %q in body:\n%s", latencyCountLine, body)
+	}
+	successLine := fmt.Sprintf("orco_update_outcome_total{outcome=\"success\",service=\"%s\"} 1", service)
+	if !strings.Contains(body, successLine) {
+		t.Fatalf("expected update success metric line %q in body:\n%s", successLine, body)
+	}
+	failureLine := fmt.Sprintf("orco_update_outcome_total{outcome=\"failure\",service=\"%s\"} 1", service)
+	if !strings.Contains(body, failureLine) {
+		t.Fatalf("expected update failure metric line %q in body:\n%s", failureLine, body)
 	}
 	quantileOptionA := fmt.Sprintf("orco_probe_latency_seconds{service=\"%s\",quantile=\"0.5\"}", service)
 	quantileOptionB := fmt.Sprintf("orco_probe_latency_seconds{quantile=\"0.5\",service=\"%s\"}", service)


### PR DESCRIPTION
## Summary
- add a Prometheus counter that tracks service update outcomes by service and result
- expose helper instrumentation and emit update outcome metrics from the apply workflow
- extend metrics endpoint tests to cover the new counter series

## Testing
- `go test ./internal/metrics -run TestRegistryExposesMetrics -count=1 -v`
- `go test ./...` *(fails: missing system libraries `gpgme`, `btrfs/version.h`, and `devmapper` required by dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68e674a473608325b091991d903351dc