### PR TITLE
Add stack schema validation and lint coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,6 +113,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
 	github.com/sigstore/fulcio v1.4.3 // indirect
 	github.com/sigstore/rekor v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -813,6 +813,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -38,6 +38,7 @@ func newConfigLintCmd() *cobra.Command {
 				return err
 			}
 
+			fmt.Fprintf(cmd.OutOrStdout(), "%s: OK\n", path)
 			return nil
 		},
 	}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,133 +10,148 @@ import (
 )
 
 func TestConfigLintSuccess(t *testing.T) {
-	dir := t.TempDir()
-	manifest := []byte(`version: 0.1
-stack:
-  name: demo
-services:
-  api:
-    image: example/api:latest
-    runtime: docker
-    health:
-      tcp:
-        address: localhost:8080
-`)
-	path := filepath.Join(dir, "stack.yaml")
-	if err := os.WriteFile(path, manifest, 0o644); err != nil {
-		t.Fatalf("write stack: %v", err)
-	}
-
-	cmd := NewRootCmd()
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	cmd.SetOut(stdout)
-	cmd.SetErr(stderr)
-	cmd.SetArgs([]string{"config", "lint", "--file", path})
-
-	if err := cmd.Execute(); err != nil {
+	manifest := stackManifest(
+		"version: 0.1",
+		"stack:",
+		"  name: demo",
+		"services:",
+		"  api:",
+		"    image: example/api:latest",
+		"    runtime: docker",
+		"    health:",
+		"      tcp:",
+		"        address: localhost:8080",
+	)
+	stdout, stderr, path, err := runConfigLint(t, manifest)
+	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if stderr.Len() != 0 {
-		t.Fatalf("unexpected stderr output: %q", stderr.String())
+	want := fmt.Sprintf("%s: OK\n", path)
+	if stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr output: %q", stderr)
 	}
 }
 
-func TestConfigLintFailure(t *testing.T) {
-	dir := t.TempDir()
-	manifest := []byte(`version: 0.1
-stack: {}
-services:
-  api:
-    image: example/api:latest
-    runtime: docker
-    health:
-      tcp:
-        address: localhost:8080
-`)
-	path := filepath.Join(dir, "stack.yaml")
-	if err := os.WriteFile(path, manifest, 0o644); err != nil {
-		t.Fatalf("write stack: %v", err)
-	}
-
-	cmd := NewRootCmd()
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	cmd.SetOut(stdout)
-	cmd.SetErr(stderr)
-	cmd.SetArgs([]string{"config", "lint", "--file", path})
-
-	if err := cmd.Execute(); err == nil {
+func TestConfigLintSchemaViolation(t *testing.T) {
+	manifest := stackManifest(
+		"version: 0.1",
+		"stack:",
+		"  name: demo",
+		"services: []",
+	)
+	stdout, stderr, _, err := runConfigLint(t, manifest)
+	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "schema validation failed") {
+		t.Fatalf("stderr does not mention schema failure: %q", stderr)
+	}
+	if !strings.Contains(stderr, "services") {
+		t.Fatalf("stderr does not mention services path: %q", stderr)
+	}
+}
 
-	if got := stderr.String(); got == "" {
+func TestConfigLintMissingStackName(t *testing.T) {
+	manifest := stackManifest(
+		"version: 0.1",
+		"stack: {}",
+		"services:",
+		"  api:",
+		"    image: example/api:latest",
+		"    runtime: docker",
+		"    health:",
+		"      tcp:",
+		"        address: localhost:8080",
+	)
+	stdout, stderr, path, err := runConfigLint(t, manifest)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr == "" {
 		t.Fatalf("expected stderr output, got empty string")
-	} else if !strings.Contains(got, "stack.yaml") {
-		t.Fatalf("stderr does not mention stack path: %q", got)
+	}
+	if !strings.Contains(stderr, filepath.Base(path)) {
+		t.Fatalf("stderr does not mention stack path: %q", stderr)
 	}
 }
 
 func TestConfigLintDockerRequiresImage(t *testing.T) {
-	dir := t.TempDir()
-	manifest := []byte(`version: 0.1
-stack:
-  name: demo
-services:
-  api:
-    runtime: docker
-    health:
-      tcp:
-        address: localhost:8080
-`)
-	path := filepath.Join(dir, "stack.yaml")
-	if err := os.WriteFile(path, manifest, 0o644); err != nil {
-		t.Fatalf("write stack: %v", err)
-	}
-
-	cmd := NewRootCmd()
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	cmd.SetOut(stdout)
-	cmd.SetErr(stderr)
-	cmd.SetArgs([]string{"config", "lint", "--file", path})
-
-	if err := cmd.Execute(); err == nil {
+	manifest := stackManifest(
+		"version: 0.1",
+		"stack:",
+		"  name: demo",
+		"services:",
+		"  api:",
+		"    runtime: docker",
+		"    health:",
+		"      tcp:",
+		"        address: localhost:8080",
+	)
+	stdout, stderr, _, err := runConfigLint(t, manifest)
+	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-
-	if got := stderr.String(); !strings.Contains(got, "services.api.image") {
-		t.Fatalf("stderr does not mention missing image: %q", got)
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "services.api.image") {
+		t.Fatalf("stderr does not mention missing image: %q", stderr)
 	}
 }
 
 func TestConfigLintProcessRequiresCommand(t *testing.T) {
+	manifest := stackManifest(
+		"version: 0.1",
+		"stack:",
+		"  name: demo",
+		"services:",
+		"  worker:",
+		"    runtime: process",
+		"    health:",
+		"      tcp:",
+		"        address: localhost:8080",
+	)
+	stdout, stderr, _, err := runConfigLint(t, manifest)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "services.worker.command") {
+		t.Fatalf("stderr does not mention missing command: %q", stderr)
+	}
+}
+
+func runConfigLint(t *testing.T, manifest string) (stdout, stderr, path string, err error) {
+	t.Helper()
 	dir := t.TempDir()
-	manifest := []byte(`version: 0.1
-stack:
-  name: demo
-services:
-  worker:
-    runtime: process
-`)
-	path := filepath.Join(dir, "stack.yaml")
-	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+	path = filepath.Join(dir, "stack.yaml")
+	if err := os.WriteFile(path, []byte(manifest), 0o644); err != nil {
 		t.Fatalf("write stack: %v", err)
 	}
 
 	cmd := NewRootCmd()
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	cmd.SetOut(stdout)
-	cmd.SetErr(stderr)
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
 	cmd.SetArgs([]string{"config", "lint", "--file", path})
 
-	if err := cmd.Execute(); err == nil {
-		t.Fatalf("expected error, got nil")
-	}
+	err = cmd.Execute()
+	return outBuf.String(), errBuf.String(), path, err
+}
 
-	if got := stderr.String(); !strings.Contains(got, "services.worker.command") {
-		t.Fatalf("stderr does not mention missing command: %q", got)
-	}
+func stackManifest(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -25,6 +25,10 @@ func Load(path string) (*Stack, error) {
 		return nil, err
 	}
 
+	if err := validateAgainstSchema(mergedDoc); err != nil {
+		return nil, fmt.Errorf("%s: %w", absPath, err)
+	}
+
 	encoded, err := yaml.Marshal(mergedDoc)
 	if err != nil {
 		return nil, fmt.Errorf("%s: marshal merged configuration: %w", absPath, err)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -213,7 +213,7 @@ services:
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "stack.name") {
+	if !strings.Contains(err.Error(), "stack: missing properties") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(err.Error(), path) {
@@ -244,6 +244,30 @@ services:
 	}
 	if !strings.Contains(err.Error(), "services.api.image") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadSchemaValidation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	manifest := []byte(`version: 0.1
+stack:
+  name: demo
+services: []
+`)
+	if err := os.WriteFile(path, manifest, 0o644); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "schema validation failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "services") {
+		t.Fatalf("schema error does not mention services path: %v", err)
 	}
 }
 
@@ -317,6 +341,9 @@ stack:
 services:
   worker:
     runtime: process
+    health:
+      tcp:
+        address: localhost:1234
 `)
 	if err := os.WriteFile(path, manifest, 0o644); err != nil {
 		t.Fatalf("write stack: %v", err)
@@ -856,7 +883,7 @@ services:
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "services.api.health") {
+	if !strings.Contains(err.Error(), "services.api: missing properties") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/config/schema_validation.go
+++ b/internal/config/schema_validation.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	orcoschema "github.com/Paintersrp/orco/schema"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+var (
+	schemaOnce  sync.Once
+	stackSchema *jsonschema.Schema
+	schemaErr   error
+)
+
+func loadStackSchema() (*jsonschema.Schema, error) {
+	schemaOnce.Do(func() {
+		compiler := jsonschema.NewCompiler()
+		compiler.Draft = jsonschema.Draft2020
+		if err := compiler.AddResource("stack.v1.json", bytes.NewReader(orcoschema.StackV1Schema)); err != nil {
+			schemaErr = fmt.Errorf("add stack schema resource: %w", err)
+			return
+		}
+		stackSchema, schemaErr = compiler.Compile("stack.v1.json")
+		if schemaErr != nil {
+			schemaErr = fmt.Errorf("compile stack schema: %w", schemaErr)
+		}
+	})
+	if schemaErr != nil {
+		return nil, schemaErr
+	}
+	return stackSchema, nil
+}
+
+func validateAgainstSchema(doc map[string]any) error {
+	schema, err := loadStackSchema()
+	if err != nil {
+		return fmt.Errorf("load stack schema: %w", err)
+	}
+
+	normalized, err := normalizeForSchema(doc)
+	if err != nil {
+		return fmt.Errorf("prepare manifest for schema validation: %w", err)
+	}
+
+	if err := schema.Validate(normalized); err != nil {
+		if vErr, ok := err.(*jsonschema.ValidationError); ok {
+			return fmt.Errorf("schema validation failed:\n%s", formatValidationError(vErr))
+		}
+		return fmt.Errorf("schema validation failed: %w", err)
+	}
+	return nil
+}
+
+func normalizeForSchema(doc map[string]any) (any, error) {
+	buf := &bytes.Buffer{}
+	encoder := json.NewEncoder(buf)
+	if err := encoder.Encode(doc); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	decoder.UseNumber()
+	var out any
+	if err := decoder.Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func formatValidationError(err *jsonschema.ValidationError) string {
+	var b strings.Builder
+	writeValidationError(&b, err, 0)
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func writeValidationError(b *strings.Builder, err *jsonschema.ValidationError, depth int) {
+	show := true
+	if len(err.Causes) > 0 && strings.HasPrefix(err.Message, "doesn't validate with") {
+		show = false
+	}
+	if show {
+		indent := strings.Repeat("  ", depth)
+		location := formatInstanceLocation(err.InstanceLocation)
+		fmt.Fprintf(b, "%s- %s: %s\n", indent, location, err.Message)
+		depth++
+	}
+	for _, cause := range err.Causes {
+		writeValidationError(b, cause, depth)
+	}
+}
+
+func formatInstanceLocation(ptr string) string {
+	if ptr == "" || ptr == "/" {
+		return "manifest"
+	}
+	segments := strings.Split(ptr, "/")
+	if len(segments) > 0 {
+		segments = segments[1:]
+	}
+	if len(segments) == 0 {
+		return "manifest"
+	}
+	var b strings.Builder
+	for _, segment := range segments {
+		decoded := strings.ReplaceAll(strings.ReplaceAll(segment, "~1", "/"), "~0", "~")
+		if _, err := strconv.Atoi(decoded); err == nil {
+			fmt.Fprintf(&b, "[%s]", decoded)
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(decoded)
+	}
+	if b.Len() == 0 {
+		return "manifest"
+	}
+	return b.String()
+}

--- a/schema/embed.go
+++ b/schema/embed.go
@@ -1,0 +1,8 @@
+package schema
+
+import _ "embed"
+
+// StackV1Schema contains the JSON schema for stack manifests.
+//
+//go:embed stack.v1.json
+var StackV1Schema []byte

--- a/schema/stack.v1.json
+++ b/schema/stack.v1.json
@@ -1,0 +1,441 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orco.dev/schema/stack.v1.json",
+  "title": "Orco stack manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "stack", "services"],
+  "properties": {
+    "version": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "includes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "stack": {
+      "$ref": "#/$defs/stackMeta"
+    },
+    "defaults": {
+      "$ref": "#/$defs/defaults"
+    },
+    "logging": {
+      "$ref": "#/$defs/logging"
+    },
+    "proxy": {
+      "$ref": "#/$defs/proxy"
+    },
+    "services": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/service"
+      }
+    }
+  },
+  "$defs": {
+    "stackMeta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "workdir": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "restartPolicy": {
+          "$ref": "#/$defs/restartPolicy"
+        },
+        "health": {
+          "$ref": "#/$defs/probe"
+        }
+      }
+    },
+    "logging": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "directory": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maxFileSize": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxTotalSize": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxFileAge": {
+          "$ref": "#/$defs/duration"
+        },
+        "maxFileCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "proxy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/proxyRoute"
+          }
+        },
+        "assets": {
+          "$ref": "#/$defs/proxyAssets"
+        }
+      }
+    },
+    "proxyRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["service", "port"],
+      "properties": {
+        "pathPrefix": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          },
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "service": {
+          "type": "string",
+          "minLength": 1
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "stripPathPrefix": {
+          "type": "boolean"
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["pathPrefix"]
+        },
+        {
+          "required": ["headers"]
+        }
+      ]
+    },
+    "proxyAssets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["directory"],
+      "properties": {
+        "directory": {
+          "type": "string",
+          "minLength": 1
+        },
+        "index": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime", "health"],
+      "properties": {
+        "image": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime": {
+          "type": "string",
+          "enum": ["docker", "podman", "process"]
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "envFromFile": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dependency"
+          }
+        },
+        "health": {
+          "$ref": "#/$defs/probe"
+        },
+        "update": {
+          "$ref": "#/$defs/updateStrategy"
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "restartPolicy": {
+          "$ref": "#/$defs/restartPolicy"
+        },
+        "resources": {
+          "$ref": "#/$defs/resources"
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "require": {
+          "type": "string",
+          "enum": ["", "ready", "started", "exists"]
+        },
+        "timeout": {
+          "$ref": "#/$defs/duration"
+        }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "gracePeriod": {
+          "$ref": "#/$defs/duration"
+        },
+        "interval": {
+          "$ref": "#/$defs/duration"
+        },
+        "timeout": {
+          "$ref": "#/$defs/duration"
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "http": {
+          "$ref": "#/$defs/httpProbe"
+        },
+        "tcp": {
+          "$ref": "#/$defs/tcpProbe"
+        },
+        "cmd": {
+          "$ref": "#/$defs/commandProbe"
+        },
+        "log": {
+          "$ref": "#/$defs/logProbe"
+        },
+        "expression": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "httpProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expectStatus": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "tcpProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["address"],
+      "properties": {
+        "address": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "commandProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "timeout": {
+          "$ref": "#/$defs/duration"
+        }
+      }
+    },
+    "logProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "levels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "updateStrategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maxUnavailable": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxSurge": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "promoteAfter": {
+          "$ref": "#/$defs/duration"
+        }
+      }
+    },
+    "restartPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxRetries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "backoff": {
+          "$ref": "#/$defs/backoff"
+        }
+      }
+    },
+    "backoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "min": {
+          "$ref": "#/$defs/duration"
+        },
+        "max": {
+          "$ref": "#/$defs/duration"
+        },
+        "factor": {
+          "type": "number"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "minLength": 1
+        },
+        "memory": {
+          "type": "string",
+          "minLength": 1
+        },
+        "memoryReservation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "duration": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define the stack manifest JSON schema and embed it in the binary
- validate merged manifests against the schema during `config load`/`lint`
- expand config lint tests to cover success, schema errors, and CLI messaging

## Testing
- go test ./internal/config
- go test ./internal/cli *(fails: missing system libraries such as gpgme/devmapper)*

------
https://chatgpt.com/codex/tasks/task_e_68e68056ec9483259b98e3dbb3306d73