### PR TITLE
Detect and report host port collisions during stack validation

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -415,6 +415,9 @@ func (s *Stack) Validate() error {
 			}
 		}
 	}
+	if err := validatePortCollisions(s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/docker/go-connections/nat"
+)
+
+type portClaim struct {
+	services map[string]struct{}
+}
+
+func validatePortCollisions(s *Stack) error {
+	if len(s.Services) == 0 {
+		return nil
+	}
+	claimed := map[string]*portClaim{}
+	for serviceName, svc := range s.Services {
+		if svc == nil {
+			continue
+		}
+		for idx, spec := range svc.Ports {
+			mappings, err := nat.ParsePortSpec(spec)
+			if err != nil {
+				return fmt.Errorf("%s: invalid port mapping %q: %w", serviceField(serviceName, fmt.Sprintf("ports[%d]", idx)), spec, err)
+			}
+			for _, mapping := range mappings {
+				hostPortSpec := strings.TrimSpace(mapping.Binding.HostPort)
+				if hostPortSpec == "" {
+					continue
+				}
+				hostIP := normalizeHostIP(mapping.Binding.HostIP)
+				start, end, err := nat.ParsePortRange(hostPortSpec)
+				if err != nil {
+					return fmt.Errorf("%s: invalid host port %q", serviceField(serviceName, fmt.Sprintf("ports[%d]", idx)), hostPortSpec)
+				}
+				startPort := int(start)
+				endPort := int(end)
+				for port := startPort; port <= endPort; port++ {
+					key := hostPortKey(hostIP, port)
+					claim := claimed[key]
+					if claim == nil {
+						claim = &portClaim{services: map[string]struct{}{}}
+						claimed[key] = claim
+					}
+					if len(claim.services) > 0 {
+						services := make([]string, 0, len(claim.services)+1)
+						for existing := range claim.services {
+							services = append(services, existing)
+						}
+						if _, seen := claim.services[serviceName]; !seen {
+							services = append(services, serviceName)
+						}
+						sort.Strings(services)
+						next := nextAvailablePort(hostIP, port, claimed)
+						if next == 0 {
+							return fmt.Errorf("%s: host port %d on IP %q conflicts with service(s) %s; no additional host ports available", serviceField(serviceName, fmt.Sprintf("ports[%d]", idx)), port, hostIP, strings.Join(services, ", "))
+						}
+						return fmt.Errorf("%s: host port %d on IP %q conflicts with service(s) %s; next available port is %d", serviceField(serviceName, fmt.Sprintf("ports[%d]", idx)), port, hostIP, strings.Join(services, ", "), next)
+					}
+					claim.services[serviceName] = struct{}{}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func nextAvailablePort(hostIP string, start int, claimed map[string]*portClaim) int {
+	for candidate := start + 1; candidate <= 65535; candidate++ {
+		if _, ok := claimed[hostPortKey(hostIP, candidate)]; !ok {
+			return candidate
+		}
+	}
+	return 0
+}
+
+func hostPortKey(hostIP string, port int) string {
+	return fmt.Sprintf("%s:%d", hostIP, port)
+}
+
+func normalizeHostIP(ip string) string {
+	ip = strings.TrimSpace(ip)
+	if ip == "" || ip == "0.0.0.0" {
+		return "0.0.0.0"
+	}
+	return ip
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePortCollisions(t *testing.T) {
+	mkService := func(ports ...string) *ServiceSpec {
+		return &ServiceSpec{
+			Runtime:  "docker",
+			Image:    "ghcr.io/demo/app:latest",
+			Replicas: 1,
+			Ports:    ports,
+			Health: &ProbeSpec{
+				HTTP: &HTTPProbeSpec{URL: "http://localhost:8080/healthz"},
+			},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		services map[string]*ServiceSpec
+		contains []string
+	}{
+		{
+			name: "conflict on wildcard interface",
+			services: map[string]*ServiceSpec{
+				"api":    mkService("8080:80"),
+				"worker": mkService("8080:80"),
+			},
+			contains: []string{
+				"host port 8080",
+				"IP \"0.0.0.0\"",
+				"service(s) api, worker",
+				"next available port is 8081",
+			},
+		},
+		{
+			name: "conflict on explicit ip with occupied successor",
+			services: map[string]*ServiceSpec{
+				"db": mkService("127.0.0.1:8080:80", "127.0.0.1:8081:81"),
+				"ui": mkService("127.0.0.1:8080:80"),
+			},
+			contains: []string{
+				"host port 8080",
+				"IP \"127.0.0.1\"",
+				"service(s) db, ui",
+				"next available port is 8082",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stack := &Stack{
+				Version:  "0.1",
+				Stack:    StackMeta{Name: "demo"},
+				Services: tc.services,
+			}
+			err := stack.Validate()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("expected error to contain %q, got %v", want, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a validation pass that tracks claimed host ports for every service in a stack
- raise a descriptive error when a collision occurs, including the conflicting services and suggested free port
- cover the new behavior with table-driven tests for wildcard and explicit host IP bindings

## Testing
- `go test ./...` *(fails: pkg-config cannot locate gpgme)*

------
https://chatgpt.com/codex/tasks/task_e_68e68c07ad8c83258d66e15406e4ee35