### PR TITLE
Ensure wildcard host port claims block specific mappings

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -39,18 +39,27 @@ func validatePortCollisions(s *Stack) error {
 				startPort := int(start)
 				endPort := int(end)
 				for port := startPort; port <= endPort; port++ {
-					key := hostPortKey(hostIP, port)
-					claim := claimed[key]
-					if claim == nil {
-						claim = &portClaim{services: map[string]struct{}{}}
-						claimed[key] = claim
+					specificKey := hostPortKey(hostIP, port)
+					wildcardKey := hostPortKey("0.0.0.0", port)
+
+					var conflictServices map[string]struct{}
+					for _, key := range []string{specificKey, wildcardKey} {
+						if claim := claimed[key]; claim != nil {
+							if conflictServices == nil {
+								conflictServices = map[string]struct{}{}
+							}
+							for existing := range claim.services {
+								conflictServices[existing] = struct{}{}
+							}
+						}
 					}
-					if len(claim.services) > 0 {
-						services := make([]string, 0, len(claim.services)+1)
-						for existing := range claim.services {
+
+					if len(conflictServices) > 0 {
+						services := make([]string, 0, len(conflictServices)+1)
+						for existing := range conflictServices {
 							services = append(services, existing)
 						}
-						if _, seen := claim.services[serviceName]; !seen {
+						if _, seen := conflictServices[serviceName]; !seen {
 							services = append(services, serviceName)
 						}
 						sort.Strings(services)
@@ -59,6 +68,15 @@ func validatePortCollisions(s *Stack) error {
 							return fmt.Errorf("%s: host port %d on IP %q conflicts with service(s) %s; no additional host ports available", serviceField(serviceName, fmt.Sprintf("ports[%d]", idx)), port, hostIP, strings.Join(services, ", "))
 						}
 						return fmt.Errorf("%s: host port %d on IP %q conflicts with service(s) %s; next available port is %d", serviceField(serviceName, fmt.Sprintf("ports[%d]", idx)), port, hostIP, strings.Join(services, ", "), next)
+					}
+
+					claim := claimed[specificKey]
+					if claim == nil {
+						claim = &portClaim{services: map[string]struct{}{}}
+						claimed[specificKey] = claim
+					}
+					if hostIP == "0.0.0.0" {
+						claimed[wildcardKey] = claim
 					}
 					claim.services[serviceName] = struct{}{}
 				}
@@ -70,7 +88,9 @@ func validatePortCollisions(s *Stack) error {
 
 func nextAvailablePort(hostIP string, start int, claimed map[string]*portClaim) int {
 	for candidate := start + 1; candidate <= 65535; candidate++ {
-		if _, ok := claimed[hostPortKey(hostIP, candidate)]; !ok {
+		specific := claimed[hostPortKey(hostIP, candidate)]
+		wildcard := claimed[hostPortKey("0.0.0.0", candidate)]
+		if (specific == nil || len(specific.services) == 0) && (wildcard == nil || len(wildcard.services) == 0) {
 			return candidate
 		}
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -37,6 +37,19 @@ func TestValidatePortCollisions(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard conflicts with explicit ip",
+			services: map[string]*ServiceSpec{
+				"web": mkService("8080:80"),
+				"api": mkService("127.0.0.1:8080:80"),
+			},
+			contains: []string{
+				"host port 8080",
+				"IP \"127.0.0.1\"",
+				"service(s) api, web",
+				"next available port is 8081",
+			},
+		},
+		{
 			name: "conflict on explicit ip with occupied successor",
 			services: map[string]*ServiceSpec{
 				"db": mkService("127.0.0.1:8080:80", "127.0.0.1:8081:81"),


### PR DESCRIPTION
## Summary
- update port collision validation to check both specific and wildcard host keys before registering claims
- ensure wildcard claims are recorded for subsequent specific lookups and adjust next available port probing
- add a regression test covering a wildcard host port conflicting with a specific IP mapping

## Testing
- go test ./internal/config

------
https://chatgpt.com/codex/tasks/task_e_68e6943a7b38832598847e8d6ddf00c0