### PR TITLE
Surface warnings for shared writable volumes

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -33,9 +33,14 @@ func newConfigLintCmd() *cobra.Command {
 				}
 			}
 
-			if _, err := config.Load(path); err != nil {
+			doc, err := config.Load(path)
+			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), err)
 				return err
+			}
+
+			for _, warning := range doc.Warnings {
+				fmt.Fprintf(cmd.OutOrStdout(), "warning: %s\n", warning)
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "%s: OK\n", path)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -53,6 +53,7 @@ type Stack struct {
 	Logging  *LoggingSpec            `yaml:"logging"`
 	Proxy    *ProxySpec              `yaml:"proxy"`
 	Services map[string]*ServiceSpec `yaml:"services"`
+	Warnings []string                `yaml:"-"`
 }
 
 // StackMeta contains metadata about the stack document.
@@ -266,6 +267,7 @@ func (s *Stack) ApplyDefaults() error {
 
 // Validate enforces schema invariants.
 func (s *Stack) Validate() error {
+	s.Warnings = nil
 	if s.Version == "" {
 		return fmt.Errorf("%s: is required", fieldPath("version"))
 	}
@@ -418,6 +420,7 @@ func (s *Stack) Validate() error {
 	if err := validatePortCollisions(s); err != nil {
 		return err
 	}
+	s.Warnings = collectVolumeConflicts(s)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- record writable host path collisions during stack validation and persist them as warnings
- surface validation warnings through `orco config lint`
- add a regression test that exercises loading a stack with conflicting writable volumes

## Testing
- go test ./internal/config...


------
https://chatgpt.com/codex/tasks/task_e_68e69948dd88832586cc131a85a96e71