### PR TITLE
Handle wildcard port suggestion collisions

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -122,6 +122,17 @@ func nextAvailablePort(hostIP string, start int, claimed map[int]map[string]*por
 			if len(hostClaims) == 0 {
 				return candidate
 			}
+
+			available := true
+			for _, claim := range hostClaims {
+				if claim != nil && len(claim.services) > 0 {
+					available = false
+					break
+				}
+			}
+			if available {
+				return candidate
+			}
 			continue
 		}
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -89,7 +89,7 @@ func TestValidatePortCollisions(t *testing.T) {
 
 func TestWildcardPortConflictsRegardlessOfOrder(t *testing.T) {
 	wildcard := testServiceSpec("0.0.0.0:8080:80")
-	specific := testServiceSpec("127.0.0.1:8080:80")
+	specific := testServiceSpec("127.0.0.1:8080:80", "127.0.0.1:8081:81")
 
 	t.Run("specific before wildcard", func(t *testing.T) {
 		claimed := map[int]map[string]*portClaim{}
@@ -102,7 +102,7 @@ func TestWildcardPortConflictsRegardlessOfOrder(t *testing.T) {
 			t.Fatalf("expected wildcard claim to fail, got nil")
 		}
 
-		for _, want := range []string{"host port 8080", "IP \"0.0.0.0\"", "service(s) specific, wildcard"} {
+		for _, want := range []string{"host port 8080", "IP \"0.0.0.0\"", "service(s) specific, wildcard", "next available port is 8082"} {
 			if !strings.Contains(err.Error(), want) {
 				t.Fatalf("expected error to contain %q, got %v", want, err)
 			}
@@ -120,7 +120,7 @@ func TestWildcardPortConflictsRegardlessOfOrder(t *testing.T) {
 			t.Fatalf("expected specific claim to fail, got nil")
 		}
 
-		for _, want := range []string{"host port 8080", "IP \"127.0.0.1\"", "service(s) specific, wildcard"} {
+		for _, want := range []string{"host port 8080", "IP \"127.0.0.1\"", "service(s) specific, wildcard", "next available port is 8081"} {
 			if !strings.Contains(err.Error(), want) {
 				t.Fatalf("expected error to contain %q, got %v", want, err)
 			}


### PR DESCRIPTION
## Summary
- ensure wildcard port suggestions skip host-specific claims when scanning available ports
- extend wildcard collision tests to assert the suggested fallback port when specific bindings already exist

## Testing
- `go test ./internal/config`


------
https://chatgpt.com/codex/tasks/task_e_68e6de1965688325bdf9ed6947c00b16