### PR TITLE
Add JSON output modes to CLI status, logs, and graph commands

### DIFF
--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -1,82 +1,190 @@
 package cli
 
 import (
-	"fmt"
-	"strings"
+        "encoding/json"
+        "fmt"
+        "sort"
+        "strings"
 
-	"github.com/spf13/cobra"
+        "github.com/spf13/cobra"
 
-	"github.com/Paintersrp/orco/internal/cliutil"
-	"github.com/Paintersrp/orco/internal/config"
-	"github.com/Paintersrp/orco/internal/engine"
+        "github.com/Paintersrp/orco/internal/cliutil"
+        "github.com/Paintersrp/orco/internal/config"
+        "github.com/Paintersrp/orco/internal/engine"
 )
 
 func newGraphCmd(ctx *context) *cobra.Command {
-	var dot bool
-	cmd := &cobra.Command{
-		Use:   "graph",
-		Short: "Render the dependency graph",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			doc, err := ctx.loadStack()
+        var outputFormat string
+        cmd := &cobra.Command{
+                Use:   "graph",
+                Short: "Render the dependency graph",
+                RunE: func(cmd *cobra.Command, args []string) error {
+                        doc, err := ctx.loadStack()
 			if err != nil {
 				return err
 			}
-			tracker := ctx.statusTracker()
-			snapshot := tracker.Snapshot()
-			if dot {
-				statuses := make(map[string]engine.GraphServiceStatus, len(snapshot))
-				for name, status := range snapshot {
-					statuses[name] = engine.GraphServiceStatus{State: status.State, Ready: status.Ready, Message: status.Message}
-				}
+                        tracker := ctx.statusTracker()
+                        snapshot := tracker.Snapshot()
 
-				depMeta := make(map[string]map[string]engine.DependencyMetadata)
-				for name, svc := range doc.File.Services {
-					if svc == nil {
-						continue
-					}
-					for _, dep := range svc.DependsOn {
-						require := dep.Require
-						if require == "" {
-							require = "ready"
-						}
-						meta := engine.DependencyMetadata{Require: require}
-						if status, ok := snapshot[name]; ok && status.State == engine.EventTypeBlocked && status.Message != "" {
-							if strings.Contains(status.Message, dep.Target) {
-								meta.BlockingReason = status.Message
-							}
-						}
-						if _, ok := depMeta[name]; !ok {
-							depMeta[name] = make(map[string]engine.DependencyMetadata)
-						}
-						depMeta[name][dep.Target] = meta
-					}
-				}
+                        format := strings.ToLower(outputFormat)
+                        if format == "" {
+                                format = "text"
+                        }
 
-				fmt.Fprint(cmd.OutOrStdout(), doc.Graph.DOT(statuses, depMeta))
-				return nil
-			}
+                        switch format {
+                        case "text":
+                                var b strings.Builder
+                                services := doc.Graph.Services()
+                                for i, svc := range services {
+                                        if i > 0 {
+                                                b.WriteByte('\n')
+                                        }
+                                        renderServiceTree(&b, doc, snapshot, svc, "", nil, true, make(map[string]bool))
+                                }
 
-			var b strings.Builder
-			services := doc.Graph.Services()
-			for i, svc := range services {
-				if i > 0 {
-					b.WriteByte('\n')
-				}
-				renderServiceTree(&b, doc, snapshot, svc, "", nil, true, make(map[string]bool))
-			}
+                                fmt.Fprint(cmd.OutOrStdout(), b.String())
+                                return nil
+                        case "dot":
+                                statuses := make(map[string]engine.GraphServiceStatus, len(snapshot))
+                                for name, status := range snapshot {
+                                        statuses[name] = engine.GraphServiceStatus{State: status.State, Ready: status.Ready, Message: status.Message}
+                                }
 
-			fmt.Fprint(cmd.OutOrStdout(), b.String())
-			return nil
-		},
-	}
-	cmd.Flags().BoolVar(&dot, "dot", false, "Render in Graphviz DOT format")
-	return cmd
+                                depMeta := make(map[string]map[string]engine.DependencyMetadata)
+                                for name, svc := range doc.File.Services {
+                                        if svc == nil {
+                                                continue
+                                        }
+                                        for _, dep := range svc.DependsOn {
+                                                require := dep.Require
+                                                if require == "" {
+                                                        require = "ready"
+                                                }
+                                                meta := engine.DependencyMetadata{Require: require}
+                                                if status, ok := snapshot[name]; ok && status.State == engine.EventTypeBlocked && status.Message != "" {
+                                                        if strings.Contains(status.Message, dep.Target) {
+                                                                meta.BlockingReason = status.Message
+                                                        }
+                                                }
+                                                if _, ok := depMeta[name]; !ok {
+                                                        depMeta[name] = make(map[string]engine.DependencyMetadata)
+                                                }
+                                                depMeta[name][dep.Target] = meta
+                                        }
+                                }
+
+                                fmt.Fprint(cmd.OutOrStdout(), doc.Graph.DOT(statuses, depMeta))
+                                return nil
+                        case "json":
+                                payload := buildGraphJSON(doc, snapshot)
+                                encoder := json.NewEncoder(cmd.OutOrStdout())
+                                return encoder.Encode(payload)
+                        default:
+                                return fmt.Errorf("unsupported output format %q", format)
+                        }
+                },
+        }
+        cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text|dot|json)")
+        return cmd
+}
+
+func buildGraphJSON(doc *cliutil.StackDocument, snapshot map[string]ServiceStatus) graphJSONDocument {
+        ordered := doc.File.ServicesSorted()
+        seen := make(map[string]struct{}, len(ordered))
+        nodes := make([]graphJSONNode, 0, len(ordered)+len(snapshot))
+        for _, name := range ordered {
+                nodes = append(nodes, graphJSONNodeFromStatus(name, snapshot[name]))
+                seen[name] = struct{}{}
+        }
+
+        extras := make([]string, 0)
+        for name := range snapshot {
+                if _, ok := seen[name]; ok {
+                        continue
+                }
+                extras = append(extras, name)
+        }
+        sort.Strings(extras)
+        for _, name := range extras {
+                nodes = append(nodes, graphJSONNodeFromStatus(name, snapshot[name]))
+        }
+
+        edges := make([]graphJSONEdge, 0)
+        for _, name := range ordered {
+                svc := doc.File.Services[name]
+                if svc == nil {
+                        continue
+                }
+                deps := svc.DependsOn
+                if len(deps) == 0 {
+                        continue
+                }
+                for _, dep := range deps {
+                        require := dep.Require
+                        if require == "" {
+                                require = "ready"
+                        }
+                        edge := graphJSONEdge{
+                                From:    name,
+                                To:      dep.Target,
+                                Require: require,
+                        }
+                        if dep.Timeout.IsSet() {
+                                edge.Timeout = dep.Timeout.Duration.String()
+                        }
+                        if status, ok := snapshot[name]; ok && status.State == engine.EventTypeBlocked && status.Message != "" {
+                                if strings.Contains(status.Message, dep.Target) {
+                                        edge.BlockingReason = status.Message
+                                }
+                        }
+                        edges = append(edges, edge)
+                }
+        }
+
+        sort.Slice(edges, func(i, j int) bool {
+                if edges[i].From != edges[j].From {
+                        return edges[i].From < edges[j].From
+                }
+                if edges[i].To != edges[j].To {
+                        return edges[i].To < edges[j].To
+                }
+                if edges[i].Require != edges[j].Require {
+                        return edges[i].Require < edges[j].Require
+                }
+                return edges[i].Timeout < edges[j].Timeout
+        })
+
+        return graphJSONDocument{
+                Stack:   doc.File.Stack.Name,
+                Version: doc.File.Version,
+                Nodes:   nodes,
+                Edges:   edges,
+        }
+}
+
+func graphJSONNodeFromStatus(name string, status ServiceStatus) graphJSONNode {
+        node := graphJSONNode{
+                Name:    name,
+                State:   status.State,
+                Ready:   status.Ready,
+                Message: status.Message,
+        }
+        if status.Restarts > 0 {
+                node.Restarts = status.Restarts
+        }
+        if status.Replicas > 0 {
+                node.Replicas = status.Replicas
+        }
+        if status.ReadyReplicas > 0 {
+                node.ReadyReplicas = status.ReadyReplicas
+        }
+        return node
 }
 
 func renderServiceTree(b *strings.Builder, doc *cliutil.StackDocument, snapshot map[string]ServiceStatus, svc string, prefix string, dep *config.DepEdge, isLast bool, visited map[string]bool) {
-	linePrefix := prefix
-	if dep != nil {
-		if isLast {
+        linePrefix := prefix
+        if dep != nil {
+                if isLast {
 			linePrefix += "└─ "
 		} else {
 			linePrefix += "├─ "
@@ -162,13 +270,38 @@ func describeServiceStatus(snapshot map[string]ServiceStatus, name string) (stri
 }
 
 func formatDependencyAnnotation(dep config.DepEdge) string {
-	require := dep.Require
-	if require == "" {
-		require = "ready"
-	}
-	parts := []string{fmt.Sprintf("require=%s", require)}
-	if dep.Timeout.IsSet() {
-		parts = append(parts, fmt.Sprintf("timeout=%s", dep.Timeout.Duration))
-	}
-	return fmt.Sprintf(" (%s)", strings.Join(parts, ", "))
+        require := dep.Require
+        if require == "" {
+                require = "ready"
+        }
+        parts := []string{fmt.Sprintf("require=%s", require)}
+        if dep.Timeout.IsSet() {
+                parts = append(parts, fmt.Sprintf("timeout=%s", dep.Timeout.Duration))
+        }
+        return fmt.Sprintf(" (%s)", strings.Join(parts, ", "))
+}
+
+type graphJSONDocument struct {
+        Stack   string           `json:"stack"`
+        Version string           `json:"version"`
+        Nodes   []graphJSONNode  `json:"nodes"`
+        Edges   []graphJSONEdge  `json:"edges"`
+}
+
+type graphJSONNode struct {
+        Name          string           `json:"name"`
+        State         engine.EventType `json:"state"`
+        Ready         bool             `json:"ready"`
+        Message       string           `json:"message,omitempty"`
+        Restarts      int              `json:"restarts,omitempty"`
+        Replicas      int              `json:"replicas,omitempty"`
+        ReadyReplicas int              `json:"readyReplicas,omitempty"`
+}
+
+type graphJSONEdge struct {
+        From           string `json:"from"`
+        To             string `json:"to"`
+        Require        string `json:"require"`
+        Timeout        string `json:"timeout,omitempty"`
+        BlockingReason string `json:"blockingReason,omitempty"`
 }

--- a/internal/cli/graph_command_test.go
+++ b/internal/cli/graph_command_test.go
@@ -1,13 +1,14 @@
 package cli
 
 import (
-	"bytes"
-	stdcontext "context"
-	"strings"
-	"testing"
-	"time"
+        "bytes"
+        "encoding/json"
+        stdcontext "context"
+        "strings"
+        "testing"
+        "time"
 
-	"github.com/Paintersrp/orco/internal/engine"
+        "github.com/Paintersrp/orco/internal/engine"
 )
 
 func TestGraphCommandRendersTreeWithStatusesAndAnnotations(t *testing.T) {
@@ -126,8 +127,8 @@ services:
 	tracker.Apply(engine.Event{Service: "db", Type: engine.EventTypeReady, Replica: 0, Timestamp: base})
 	tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeBlocked, Message: "blocked waiting for db (ready)", Replica: -1, Timestamp: base.Add(time.Second)})
 
-	cmd := newGraphCmd(ctx)
-	cmd.SetArgs([]string{"--dot"})
+        cmd := newGraphCmd(ctx)
+        cmd.SetArgs([]string{"--output", "dot"})
 
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
@@ -150,4 +151,113 @@ services:
 			t.Fatalf("expected DOT output to contain %q, got:\n%s", expected, output)
 		}
 	}
+}
+
+func TestGraphCommandJSONOutput(t *testing.T) {
+        t.Parallel()
+
+        stackPath := writeStackFile(t, `version: "0.1"
+stack:
+  name: "demo"
+  workdir: "."
+defaults:
+  health:
+    cmd:
+      command: ["true"]
+services:
+  api:
+    runtime: process
+    command: ["sleep", "1"]
+    dependsOn:
+      - target: db
+        timeout: 30s
+  db:
+    runtime: process
+    command: ["sleep", "1"]
+`)
+
+        ctx := &context{stackFile: &stackPath}
+        tracker := ctx.statusTracker()
+
+        base := time.Now()
+        tracker.Apply(engine.Event{Service: "db", Type: engine.EventTypeReady, Timestamp: base})
+        tracker.Apply(engine.Event{Service: "api", Type: engine.EventTypeBlocked, Message: "waiting for db", Timestamp: base.Add(5 * time.Second)})
+
+        cmd := newGraphCmd(ctx)
+        cmd.SetArgs([]string{"--output", "json"})
+
+        var stdout, stderr bytes.Buffer
+        cmd.SetOut(&stdout)
+        cmd.SetErr(&stderr)
+
+        if err := cmd.Execute(); err != nil {
+                t.Fatalf("graph command failed: %v\nstderr: %s", err, stderr.String())
+        }
+
+        var payload struct {
+                Stack   string `json:"stack"`
+                Version string `json:"version"`
+                Nodes   []struct {
+                        Name    string           `json:"name"`
+                        State   engine.EventType `json:"state"`
+                        Ready   bool             `json:"ready"`
+                        Message string           `json:"message"`
+                } `json:"nodes"`
+                Edges []struct {
+                        From           string `json:"from"`
+                        To             string `json:"to"`
+                        Require        string `json:"require"`
+                        Timeout        string `json:"timeout"`
+                        BlockingReason string `json:"blockingReason"`
+                } `json:"edges"`
+        }
+
+        if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+                t.Fatalf("failed to parse json output: %v\noutput: %s", err, stdout.String())
+        }
+
+        if payload.Stack != "demo" {
+                t.Fatalf("expected stack demo, got %s", payload.Stack)
+        }
+        if payload.Version != "0.1" {
+                t.Fatalf("expected version 0.1, got %s", payload.Version)
+        }
+
+        if len(payload.Nodes) < 2 {
+                t.Fatalf("expected at least two nodes, got %d", len(payload.Nodes))
+        }
+
+        var apiNodeFound, edgeFound bool
+        for _, node := range payload.Nodes {
+                if node.Name == "api" {
+                        apiNodeFound = true
+                        if node.State != engine.EventTypeBlocked {
+                                t.Fatalf("expected api state blocked, got %s", node.State)
+                        }
+                        if node.Message != "waiting for db" {
+                                t.Fatalf("expected api message to match, got %s", node.Message)
+                        }
+                }
+        }
+        if !apiNodeFound {
+                t.Fatalf("expected api node in payload: %#v", payload.Nodes)
+        }
+
+        for _, edge := range payload.Edges {
+                if edge.From == "api" && edge.To == "db" {
+                        edgeFound = true
+                        if edge.Require != "ready" {
+                                t.Fatalf("expected require metadata 'ready', got %s", edge.Require)
+                        }
+                        if edge.Timeout != "30s" {
+                                t.Fatalf("expected timeout metadata '30s', got %s", edge.Timeout)
+                        }
+                        if edge.BlockingReason != "waiting for db" {
+                                t.Fatalf("expected blocking reason to match, got %s", edge.BlockingReason)
+                        }
+                }
+        }
+        if !edgeFound {
+                t.Fatalf("expected dependency edge from api to db: %#v", payload.Edges)
+        }
 }

--- a/internal/cli/logs_integration_test.go
+++ b/internal/cli/logs_integration_test.go
@@ -49,7 +49,7 @@ services:
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"-f"})
+        cmd.SetArgs([]string{"-f", "--output", "json"})
 
 	cmdCtx, cancel := stdcontext.WithCancel(stdcontext.Background())
 	cmd.SetContext(cmdCtx)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,123 +1,242 @@
 package cli
 
 import (
-	"fmt"
-	"strings"
-	"text/tabwriter"
-	"time"
+        "encoding/json"
+        "fmt"
+        "strings"
+        "text/tabwriter"
+        "time"
 
-	"github.com/spf13/cobra"
+        "github.com/spf13/cobra"
 
-	units "github.com/docker/go-units"
+        units "github.com/docker/go-units"
 
-	"github.com/Paintersrp/orco/internal/config"
-	"github.com/Paintersrp/orco/internal/engine"
-	"github.com/Paintersrp/orco/internal/resources"
+        "github.com/Paintersrp/orco/internal/api"
+        "github.com/Paintersrp/orco/internal/cliutil"
+        "github.com/Paintersrp/orco/internal/config"
+        "github.com/Paintersrp/orco/internal/engine"
+        "github.com/Paintersrp/orco/internal/resources"
 )
 
 func newStatusCmd(ctx *context) *cobra.Command {
-	var historyLimit int
+        var historyLimit int
+        var outputFormat string
 
-	cmd := &cobra.Command{
-		Use:   "status",
-		Short: "Display a summary of services defined in the stack",
-		RunE: func(cmd *cobra.Command, args []string) error {
+        cmd := &cobra.Command{
+                Use:   "status",
+                Short: "Display a summary of services defined in the stack",
+                RunE: func(cmd *cobra.Command, args []string) error {
 			doc, err := ctx.loadStack()
 			if err != nil {
 				return err
 			}
-			tracker := ctx.statusTracker()
+                        tracker := ctx.statusTracker()
 
-			orderedServices := doc.File.ServicesSorted()
-			resourceHints := make(map[string]ResourceHint, len(orderedServices))
-			for _, name := range orderedServices {
-				svc := doc.File.Services[name]
-				resourceHints[name] = buildResourceHint(svc)
-			}
-			tracker.SetResourceHints(resourceHints)
-			snapshot := tracker.Snapshot()
+                        orderedServices := doc.File.ServicesSorted()
+                        resourceHints := make(map[string]ResourceHint, len(orderedServices))
+                        for _, name := range orderedServices {
+                                svc := doc.File.Services[name]
+                                resourceHints[name] = buildResourceHint(svc)
+                        }
+                        tracker.SetResourceHints(resourceHints)
+                        snapshot := tracker.Snapshot()
 
-			out := cmd.OutOrStdout()
-			w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "SERVICE\tSTATE\tREADY\tREPL\tCPU/MEM\tRESTARTS\tAGE\tMESSAGE")
-			for _, name := range orderedServices {
-				status, ok := snapshot[name]
-				state := formatStatusState(status.State)
-				ready := "-"
-				replicas := "-"
-				restarts := 0
-				age := "-"
-				message := "-"
-				resource := formatCombinedResourceHint(resourceHints[name])
-				if ok {
-					if status.FirstSeen.IsZero() {
-						age = "-"
-					} else {
-						ageDur := time.Since(status.FirstSeen)
-						if ageDur < 0 {
-							ageDur = 0
-						}
-						ageDur = ageDur.Truncate(time.Second)
-						age = ageDur.String()
-					}
-					readyState := "No"
-					if status.Ready {
-						readyState = "Yes"
-					}
-					totalReplicas := status.Replicas
-					if totalReplicas > 0 {
-						readyReplicas := status.ReadyReplicas
-						if readyReplicas > totalReplicas {
-							readyReplicas = totalReplicas
-						}
-						ready = fmt.Sprintf("%s (%d/%d)", readyState, readyReplicas, totalReplicas)
-						replicas = fmt.Sprintf("%d", totalReplicas)
-					} else {
-						ready = readyState
-					}
-					restarts = status.Restarts
-					if status.Message != "" {
-						message = status.Message
-					} else {
-						message = "-"
-					}
-					state = formatStatusState(status.State)
-					resource = formatCombinedResourceHint(status.Resources)
-					if resource == "-" {
-						resource = formatCombinedResourceHint(resourceHints[name])
-					}
-				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n", name, state, ready, replicas, resource, restarts, age, message)
-			}
-			w.Flush()
-			fmt.Fprintf(out, "\nStack: %s (version %s)\n", doc.File.Stack.Name, doc.File.Version)
-			fmt.Fprintf(out, "Validated at %s\n", time.Now().Format(time.RFC3339))
+                        format := strings.ToLower(outputFormat)
+                        if format == "" {
+                                format = "text"
+                        }
 
-			if historyLimit > 0 {
-				for _, name := range orderedServices {
-					history := tracker.History(name, historyLimit)
-					if len(history) == 0 {
-						continue
-					}
-					fmt.Fprintf(out, "\n%s history:\n", name)
-					for _, entry := range history {
-						reason := entry.Reason
-						if reason == "" {
-							reason = "-"
-						}
-						fmt.Fprintf(out, "  %s  %-10s  %-20s  %s\n",
-							entry.Timestamp.Format(time.RFC3339),
-							formatStatusState(entry.Type),
-							reason,
-							entry.Message)
-					}
-				}
-			}
-			return nil
-		},
-	}
-	cmd.Flags().IntVar(&historyLimit, "history", 0, "Show last N transitions per service")
-	return cmd
+                        switch format {
+                        case "text":
+                                out := cmd.OutOrStdout()
+                                w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+                                fmt.Fprintln(w, "SERVICE\tSTATE\tREADY\tREPL\tCPU/MEM\tRESTARTS\tAGE\tMESSAGE")
+                                for _, name := range orderedServices {
+                                        status, ok := snapshot[name]
+                                        state := formatStatusState(status.State)
+                                        ready := "-"
+                                        replicas := "-"
+                                        restarts := 0
+                                        age := "-"
+                                        message := "-"
+                                        resource := formatCombinedResourceHint(resourceHints[name])
+                                        if ok {
+                                                if status.FirstSeen.IsZero() {
+                                                        age = "-"
+                                                } else {
+                                                        ageDur := time.Since(status.FirstSeen)
+                                                        if ageDur < 0 {
+                                                                ageDur = 0
+                                                        }
+                                                        ageDur = ageDur.Truncate(time.Second)
+                                                        age = ageDur.String()
+                                                }
+                                                readyState := "No"
+                                                if status.Ready {
+                                                        readyState = "Yes"
+                                                }
+                                                totalReplicas := status.Replicas
+                                                if totalReplicas > 0 {
+                                                        readyReplicas := status.ReadyReplicas
+                                                        if readyReplicas > totalReplicas {
+                                                                readyReplicas = totalReplicas
+                                                        }
+                                                        ready = fmt.Sprintf("%s (%d/%d)", readyState, readyReplicas, totalReplicas)
+                                                        replicas = fmt.Sprintf("%d", totalReplicas)
+                                                } else {
+                                                        ready = readyState
+                                                }
+                                                restarts = status.Restarts
+                                                if status.Message != "" {
+                                                        message = status.Message
+                                                } else {
+                                                        message = "-"
+                                                }
+                                                state = formatStatusState(status.State)
+                                                resource = formatCombinedResourceHint(status.Resources)
+                                                if resource == "-" {
+                                                        resource = formatCombinedResourceHint(resourceHints[name])
+                                                }
+                                        }
+                                        fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n", name, state, ready, replicas, resource, restarts, age, message)
+                                }
+                                w.Flush()
+                                fmt.Fprintf(out, "\nStack: %s (version %s)\n", doc.File.Stack.Name, doc.File.Version)
+                                fmt.Fprintf(out, "Validated at %s\n", time.Now().Format(time.RFC3339))
+
+                                if historyLimit > 0 {
+                                        for _, name := range orderedServices {
+                                                history := tracker.History(name, historyLimit)
+                                                if len(history) == 0 {
+                                                        continue
+                                                }
+                                                fmt.Fprintf(out, "\n%s history:\n", name)
+                                                for _, entry := range history {
+                                                        reason := entry.Reason
+                                                        if reason == "" {
+                                                                reason = "-"
+                                                        }
+                                                        fmt.Fprintf(out, "  %s  %-10s  %-20s  %s\n",
+                                                                entry.Timestamp.Format(time.RFC3339),
+                                                                formatStatusState(entry.Type),
+                                                                reason,
+                                                                entry.Message)
+                                                }
+                                        }
+                                }
+                                return nil
+                        case "json":
+                                out := cmd.OutOrStdout()
+                                report, err := buildStatusReport(doc, tracker, snapshot, historyLimit)
+                                if err != nil {
+                                        return err
+                                }
+                                encoder := json.NewEncoder(out)
+                                return encoder.Encode(report)
+                        default:
+                                return fmt.Errorf("unsupported output format %q", format)
+                        }
+                },
+        }
+        cmd.Flags().IntVar(&historyLimit, "history", 0, "Show last N transitions per service")
+        cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text|json)")
+        return cmd
+}
+
+func buildStatusReport(doc *cliutil.StackDocument, tracker *statusTracker, snapshot map[string]ServiceStatus, historyLimit int) (*api.StatusReport, error) {
+        if doc == nil || doc.File == nil {
+                return nil, fmt.Errorf("invalid stack document")
+        }
+
+        historyDepth := defaultHistoryDepth
+        if historyLimit > 0 {
+                historyDepth = historyLimit
+        }
+
+        services := make(map[string]api.ServiceReport, len(doc.File.Services)+len(snapshot))
+        for _, name := range doc.File.ServicesSorted() {
+                status, ok := snapshot[name]
+                if !ok {
+                        services[name] = api.ServiceReport{Name: name}
+                        continue
+                }
+                history := tracker.History(name, historyDepth)
+                apiHistory := make([]api.ServiceTransition, 0, len(history))
+                for _, entry := range history {
+                        apiHistory = append(apiHistory, api.ServiceTransition{
+                                Timestamp: entry.Timestamp,
+                                Type:      entry.Type,
+                                Reason:    entry.Reason,
+                                Message:   entry.Message,
+                        })
+                }
+                lastReason := ""
+                if len(apiHistory) > 0 {
+                        lastReason = apiHistory[len(apiHistory)-1].Reason
+                }
+                services[name] = api.ServiceReport{
+                        Name:          status.Name,
+                        State:         status.State,
+                        Ready:         status.Ready,
+                        Restarts:      status.Restarts,
+                        Replicas:      status.Replicas,
+                        ReadyReplicas: status.ReadyReplicas,
+                        Message:       status.Message,
+                        FirstSeen:     status.FirstSeen,
+                        LastEvent:     status.LastEvent,
+                        Resources: api.ResourceHint{
+                                CPU:    status.Resources.CPU,
+                                Memory: status.Resources.Memory,
+                        },
+                        History:    apiHistory,
+                        LastReason: lastReason,
+                }
+        }
+
+        for name, status := range snapshot {
+                if _, ok := services[name]; ok {
+                        continue
+                }
+                history := tracker.History(name, historyDepth)
+                apiHistory := make([]api.ServiceTransition, 0, len(history))
+                for _, entry := range history {
+                        apiHistory = append(apiHistory, api.ServiceTransition{
+                                Timestamp: entry.Timestamp,
+                                Type:      entry.Type,
+                                Reason:    entry.Reason,
+                                Message:   entry.Message,
+                        })
+                }
+                lastReason := ""
+                if len(apiHistory) > 0 {
+                        lastReason = apiHistory[len(apiHistory)-1].Reason
+                }
+                services[name] = api.ServiceReport{
+                        Name:          status.Name,
+                        State:         status.State,
+                        Ready:         status.Ready,
+                        Restarts:      status.Restarts,
+                        Replicas:      status.Replicas,
+                        ReadyReplicas: status.ReadyReplicas,
+                        Message:       status.Message,
+                        FirstSeen:     status.FirstSeen,
+                        LastEvent:     status.LastEvent,
+                        Resources: api.ResourceHint{
+                                CPU:    status.Resources.CPU,
+                                Memory: status.Resources.Memory,
+                        },
+                        History:    apiHistory,
+                        LastReason: lastReason,
+                }
+        }
+
+        report := &api.StatusReport{
+                Stack:       doc.File.Stack.Name,
+                Version:     doc.File.Version,
+                GeneratedAt: time.Now(),
+                Services:    services,
+        }
+        return report, nil
 }
 
 func formatStatusState(t engine.EventType) string {


### PR DESCRIPTION
## Summary
- add a shared --output flag to the status, logs, and graph commands with validation of supported formats
- emit status snapshots through api.StatusReport when --output json is selected and expose a structured JSON shape for graph output
- cover the new JSON modes in the CLI tests, including logs NDJSON output when the flag is explicitly set

## Testing
- go test ./internal/cli/... *(fails: missing btrfs/ioctl.h and devmapper system headers)*

------
https://chatgpt.com/codex/tasks/task_e_68e701ea01888325ad29c7106878bb90