### PR TITLE
Add validation for blue-green switch configuration

### DIFF
--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -312,14 +312,18 @@ func (h *serviceHandle) updateBlueGreen(ctx context.Context, newSpec, previous *
 		}
 	}
 
-	sendEvent(h.events, h.name, -1, EventTypeUpdatePhase, "performing cutover to green replica set", 0, ReasonBlueGreenCutover, nil)
-
 	rollbackWindow := time.Duration(0)
 	drainTimeout := time.Duration(0)
+	switchMode := stack.BlueGreenSwitchPorts
 	if newSpec.Update != nil && newSpec.Update.BlueGreen != nil {
 		rollbackWindow = newSpec.Update.BlueGreen.RollbackWindow.Duration
 		drainTimeout = newSpec.Update.BlueGreen.DrainTimeout.Duration
+		if mode := strings.TrimSpace(newSpec.Update.BlueGreen.Switch); mode != "" {
+			switchMode = mode
+		}
 	}
+
+	sendEvent(h.events, h.name, -1, EventTypeUpdatePhase, fmt.Sprintf("performing cutover to green replica set (switch=%s)", switchMode), 0, ReasonBlueGreenCutover, nil)
 
 	h.replicas = green
 	h.service = newSpec

--- a/internal/stack/types.go
+++ b/internal/stack/types.go
@@ -24,3 +24,8 @@ type (
 	Backoff       = config.BackoffSpec
 	Resources     = config.Resources
 )
+
+const (
+	BlueGreenSwitchPorts      = config.BlueGreenSwitchPorts
+	BlueGreenSwitchProxyLabel = config.BlueGreenSwitchProxyLabel
+)


### PR DESCRIPTION
## Summary
- add named constants for blue/green switch modes and enforce canonical values during stack validation
- cover switch validation with unit tests and re-export the constants through the stack package
- surface the configured switch mode during blue/green cutover events

## Testing
- go test ./internal/config -run BlueGreen -count=1
- go test ./internal/engine -run BlueGreen -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e83576fc188325a833248806a1c878