### PR TITLE
Document blue/green updates and extend schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ HTTP, TCP, command, and log probes can be mixed per service. Each probe has conf
 
 Rolling updates update one replica at a time. Parameters such as `maxUnavailable` and `maxSurge` constrain concurrency, ensuring availability while updates proceed. Setting `update.strategy: canary` limits the rollout to a single replica until a promotion is triggered, enabling targeted validation before continuing.
 
+### Blue/green updates
+
+For services that require atomic cutovers, set `update.strategy: blueGreen`. The orchestrator provisions a full duplicate (green) replica set and drives four observable phases via `UpdatePhase` events: `ProvisionGreen`, `Verify`, `Cutover`, and `DecommissionBlue`. Traffic remains on the blue replica set until all green replicas report readiness, at which point a single cutover switches either host ports or proxy labels depending on `update.blueGreen.switch`. Optional `drainTimeout` and `rollbackWindow` values control how long to wait for old replicas to drain and how long to watch the green set for regressions, respectively. If verification fails, Orco tears down the green set, keeps blue replicas serving traffic, and emits a rollback reason. See `examples/bluegreen-stack.yaml` for a reference manifest.
+
 ### Canary rollouts
 
 When a canary rollout is in progress Orco restarts one replica, waits for it to become healthy, and emits a `Canary` event. You can then run `orco promote <service>` to continue the rollout, or declare `update.promoteAfter` to automatically promote after a soak period (for example `promoteAfter: 5m`). The `examples/canary-stack.yaml` manifest demonstrates a complete configuration.

--- a/examples/bluegreen-stack.yaml
+++ b/examples/bluegreen-stack.yaml
@@ -1,0 +1,43 @@
+version: 1
+
+stack:
+  name: bluegreen-demo
+
+services:
+  db:
+    runtime: docker
+    image: postgres:16
+    env:
+      POSTGRES_PASSWORD: postgres
+    ports: ["5432:5432"]
+    health:
+      tcp:
+        address: 127.0.0.1:5432
+        interval: 3s
+        timeout: 1s
+        failures: 5
+
+  api:
+    runtime: docker
+    image: ghcr.io/example/api:1.2.3
+    command: ["./server"]
+    replicas: 2
+    env:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/app?sslmode=disable
+    dependsOn:
+      - target: db
+        require: ready
+    ports: ["8080:8080"]
+    health:
+      http:
+        url: http://127.0.0.1:8080/healthz
+        expectStatus: [200]
+        interval: 5s
+        timeout: 2s
+        failureThreshold: 3
+    update:
+      strategy: blueGreen
+      blueGreen:
+        switch: proxyLabel
+        drainTimeout: 30s
+        rollbackWindow: 1m

--- a/schema/stack.v1.json
+++ b/schema/stack.v1.json
@@ -385,6 +385,9 @@
         },
         "promoteAfter": {
           "$ref": "#/$defs/duration"
+        },
+        "blueGreen": {
+          "$ref": "#/$defs/blueGreenStrategy"
         }
       }
     },
@@ -398,6 +401,22 @@
         },
         "backoff": {
           "$ref": "#/$defs/backoff"
+        }
+      }
+    },
+    "blueGreenStrategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "drainTimeout": {
+          "$ref": "#/$defs/duration"
+        },
+        "rollbackWindow": {
+          "$ref": "#/$defs/duration"
+        },
+        "switch": {
+          "type": "string",
+          "enum": ["ports", "proxyLabel"]
         }
       }
     },


### PR DESCRIPTION
## Summary
- document the blue/green update workflow in the README
- extend the stack manifest schema to allow the `update.blueGreen` block
- add an example stack manifest demonstrating blue/green configuration

## Testing
- `go test ./internal/config -run BlueGreen -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68e8409acfc483258672f123578c93e1