### PR TITLE
Improve blue-green rollback messaging

### DIFF
--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -307,7 +307,8 @@ func (h *serviceHandle) updateBlueGreen(ctx context.Context, newSpec, previous *
 		if err := replica.awaitReady(ctx); err != nil {
 			shutdownReplicaSet(ctx, green)
 			cause := fmt.Errorf("green replica %d readiness failed: %w", replica.index, err)
-			sendEvent(h.events, h.name, replica.index, EventTypeAborted, "blue-green update aborted", 0, ReasonBlueGreenRollback, cause)
+			message := fmt.Sprintf("blue-green verification failed: %v", cause)
+			sendEvent(h.events, h.name, replica.index, EventTypeAborted, message, 0, ReasonBlueGreenRollback, cause)
 			return fmt.Errorf("service %s blue-green verification failed: %w", h.name, cause)
 		}
 	}
@@ -380,7 +381,8 @@ func (h *serviceHandle) updateBlueGreen(ctx context.Context, newSpec, previous *
 				h.service = previous
 			}
 			err := fmt.Errorf("service %s blue-green rollback triggered: %w", h.name, rollbackErr)
-			sendEvent(h.events, h.name, -1, EventTypeAborted, "blue-green rollback initiated", 0, ReasonBlueGreenRollback, err)
+			message := fmt.Sprintf("blue-green rollback initiated: %v", rollbackErr)
+			sendEvent(h.events, h.name, -1, EventTypeAborted, message, 0, ReasonBlueGreenRollback, err)
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- include the failure reason in the blue-green verification aborted event message
- surface the rollback failure details when a rollback window triggers

## Testing
- GOFLAGS="-tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper" go test ./internal/engine -run BlueGreen -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e84aa0bccc8325ad4e2f3a3d2e59b8