### PR TITLE
Add update strategy failure controls

### DIFF
--- a/docs/bluegreen.md
+++ b/docs/bluegreen.md
@@ -13,4 +13,9 @@ Optional settings under `update.blueGreen` provide additional control:
 - `rollbackWindow`: how long to watch green replicas for regressions and automatically roll back if a failure occurs.
 - `switch`: the traffic switching mode (`ports` or `proxyLabel`).
 
+In addition to the blue/green specific knobs, all strategies respect two global safeguards:
+
+- `update.abortAfterFailures`: aborts the rollout after the configured number of failed promotions.
+- `update.observationWindow`: sets the rolling time window used to count those failures.
+
 If verification fails or a regression occurs during the rollback window, Orco aborts the update, tears down the green replica set, and leaves the blue replicas serving traffic. See `examples/bluegreen-stack.yaml` for a reference manifest.

--- a/examples/bluegreen-stack.yaml
+++ b/examples/bluegreen-stack.yaml
@@ -37,6 +37,8 @@ services:
         failureThreshold: 3
     update:
       strategy: blueGreen
+      abortAfterFailures: 2
+      observationWindow: 3m
       blueGreen:
         switch: proxyLabel
         drainTimeout: 30s

--- a/examples/canary-stack.yaml
+++ b/examples/canary-stack.yaml
@@ -21,6 +21,8 @@ services:
     update:
       strategy: canary
       promoteAfter: 30s
+      abortAfterFailures: 3
+      observationWindow: 2m
 
   web:
     runtime: process

--- a/examples/demo-stack.yaml
+++ b/examples/demo-stack.yaml
@@ -41,6 +41,8 @@ services:
       strategy: rolling
       maxUnavailable: 0
       maxSurge: 1
+      abortAfterFailures: 4
+      observationWindow: 5m
     replicas: 1
 
   api:

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -44,6 +44,9 @@ services:
         pattern: "ready"
         sources: [stderr]
       expression: http || log
+    update:
+      abortAfterFailures: 2
+      observationWindow: 45s
 `)
 	if err := os.WriteFile(stackPath, manifest, 0o644); err != nil {
 		t.Fatalf("write stack: %v", err)
@@ -102,6 +105,15 @@ services:
 	}
 	if got, want := svc.Health.SuccessThreshold, 1; got != want {
 		t.Fatalf("success threshold mismatch: got %d want %d", got, want)
+	}
+	if svc.Update == nil {
+		t.Fatalf("update strategy not loaded")
+	}
+	if got, want := svc.Update.AbortAfterFailures, 2; got != want {
+		t.Fatalf("abortAfterFailures mismatch: got %d want %d", got, want)
+	}
+	if got, want := svc.Update.ObservationWindow.Duration, 45*time.Second; got != want {
+		t.Fatalf("observationWindow mismatch: got %v want %v", got, want)
 	}
 }
 

--- a/schema/stack.v1.json
+++ b/schema/stack.v1.json
@@ -386,6 +386,13 @@
         "promoteAfter": {
           "$ref": "#/$defs/duration"
         },
+        "abortAfterFailures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "observationWindow": {
+          "$ref": "#/$defs/duration"
+        },
         "blueGreen": {
           "$ref": "#/$defs/blueGreenStrategy"
         }


### PR DESCRIPTION
## Summary
- add abortAfterFailures and observationWindow knobs to update strategies and enforce non-negative validation
- update schema, loader tests, and examples to surface the new fields
- document the new safeguards in the blue/green guide

## Testing
- go test ./... *(fails: missing system libraries for gpgme/devmapper/btrfs)*

------
https://chatgpt.com/codex/tasks/task_e_68e864040b6883259aaf78128596d147