### PR TITLE
Add lifecycle hook configuration to services

### DIFF
--- a/internal/stack/types.go
+++ b/internal/stack/types.go
@@ -18,6 +18,8 @@ type (
 	TCPProbe      = config.TCPProbeSpec
 	CommandProbe  = config.CommandProbe
 	LogProbe      = config.LogProbeSpec
+	ServiceHooks  = config.ServiceHooks
+	LifecycleHook = config.LifecycleHookSpec
 	UpdatePolicy  = config.UpdateStrategy
 	BlueGreen     = config.BlueGreenStrategy
 	RestartPolicy = config.RestartPolicy

--- a/schema/stack.v1.json
+++ b/schema/stack.v1.json
@@ -237,6 +237,9 @@
         },
         "resources": {
           "$ref": "#/$defs/resources"
+        },
+        "hooks": {
+          "$ref": "#/$defs/serviceHooks"
         }
       }
     },
@@ -255,6 +258,52 @@
         },
         "timeout": {
           "$ref": "#/$defs/duration"
+        }
+      }
+    },
+    "serviceHooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "preStart": {
+          "$ref": "#/$defs/serviceHook"
+        },
+        "postStart": {
+          "$ref": "#/$defs/serviceHook"
+        },
+        "preStop": {
+          "$ref": "#/$defs/serviceHook"
+        },
+        "postStop": {
+          "$ref": "#/$defs/serviceHook"
+        }
+      }
+    },
+    "serviceHook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "timeout": {
+          "$ref": "#/$defs/duration"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- add lifecycle hook configuration to service specifications and expose the types through the stack package
- validate hook commands, timeouts, and options while updating the JSON schema to accept the new fields
- add unit tests for service hook validation and cloning

## Testing
- `go test ./internal/config`
- `go test ./...` *(fails: requires system packages gpgme/devmapper)*

------
https://chatgpt.com/codex/tasks/task_e_68e97469f5dc8325aea3b6909db5db4f