### PR TITLE
Add lifecycle hook execution to supervisor

### DIFF
--- a/internal/engine/events.go
+++ b/internal/engine/events.go
@@ -60,8 +60,9 @@ const (
 	ReasonBlueGreenProvision    = "bluegreen_provision"
 	ReasonBlueGreenVerify       = "bluegreen_verify"
 	ReasonBlueGreenCutover      = "bluegreen_cutover"
-	ReasonBlueGreenDecommission = "bluegreen_decommission"
-	ReasonBlueGreenRollback     = "bluegreen_rollback"
+        ReasonBlueGreenDecommission = "bluegreen_decommission"
+        ReasonBlueGreenRollback     = "bluegreen_rollback"
+        ReasonHookFailed            = "hook_failed"
 )
 
 // BlueGreenPhase enumerates the major milestones emitted while executing a

--- a/internal/engine/hooks.go
+++ b/internal/engine/hooks.go
@@ -1,0 +1,170 @@
+package engine
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/stack"
+)
+
+type hookExecutor interface {
+	Run(ctx context.Context, svc *stack.Service, phase string, hook *stack.LifecycleHook) hookResult
+}
+
+type hookResult struct {
+	Phase    string
+	Command  []string
+	Logs     []hookLog
+	Err      error
+	TimedOut bool
+}
+
+type hookLog struct {
+	Message string
+	Stream  string
+}
+
+const (
+	hookStreamStdout = "stdout"
+	hookStreamStderr = "stderr"
+)
+
+type commandHookExecutor struct {
+	now func() time.Time
+}
+
+func newCommandHookExecutor() *commandHookExecutor {
+	return &commandHookExecutor{now: time.Now}
+}
+
+func (e *commandHookExecutor) Run(ctx context.Context, svc *stack.Service, phase string, hook *stack.LifecycleHook) hookResult {
+	res := hookResult{Phase: phase}
+	if hook == nil || len(hook.Command) == 0 {
+		return res
+	}
+	res.Command = append(res.Command, hook.Command...)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if hook.Timeout.Duration > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, hook.Timeout.Duration)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, hook.Command[0], hook.Command[1:]...)
+	cmd.Env = mergeServiceEnv(os.Environ(), svc)
+	if svc != nil && svc.ResolvedWorkdir != "" {
+		cmd.Dir = svc.ResolvedWorkdir
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	if err := cmd.Start(); err != nil {
+		res.Err = err
+		return res
+	}
+
+	logsCh := make(chan hookLog, 16)
+	var wg sync.WaitGroup
+
+	scan := func(r io.Reader, stream string) {
+		defer wg.Done()
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			logsCh <- hookLog{Message: scanner.Text(), Stream: stream}
+		}
+	}
+
+	wg.Add(2)
+	go scan(stdout, hookStreamStdout)
+	go scan(stderr, hookStreamStderr)
+
+	go func() {
+		wg.Wait()
+		close(logsCh)
+	}()
+
+	waitErr := cmd.Wait()
+
+	for entry := range logsCh {
+		res.Logs = append(res.Logs, entry)
+	}
+
+	if waitErr != nil {
+		if errors.Is(waitErr, context.DeadlineExceeded) {
+			res.TimedOut = true
+			res.Err = context.DeadlineExceeded
+			return res
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			res.TimedOut = true
+			res.Err = context.DeadlineExceeded
+			return res
+		}
+		if errors.Is(ctx.Err(), context.Canceled) && !errors.Is(waitErr, context.Canceled) {
+			res.Err = context.Canceled
+			return res
+		}
+		res.Err = waitErr
+		return res
+	}
+
+	if err := ctx.Err(); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			res.TimedOut = true
+		}
+		res.Err = err
+	}
+
+	return res
+}
+
+func mergeServiceEnv(base []string, svc *stack.Service) []string {
+	if svc == nil || len(svc.Env) == 0 {
+		dup := append([]string(nil), base...)
+		return dup
+	}
+	env := append([]string(nil), base...)
+	keys := make([]string, 0, len(svc.Env))
+	for k := range svc.Env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		env = append(env, fmt.Sprintf("%s=%s", k, svc.Env[k]))
+	}
+	return env
+}
+
+func joinCommand(cmd []string) string {
+	if len(cmd) == 0 {
+		return ""
+	}
+	parts := make([]string, len(cmd))
+	copy(parts, cmd)
+	for i, part := range parts {
+		if strings.ContainsAny(part, " \t\n\"") {
+			parts[i] = fmt.Sprintf("%q", part)
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/engine/hooks_test.go
+++ b/internal/engine/hooks_test.go
@@ -1,0 +1,93 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/orco/internal/stack"
+)
+
+func TestCommandHookExecutorRunsCommand(t *testing.T) {
+	dir := t.TempDir()
+
+	svc := &stack.Service{
+		ResolvedWorkdir: dir,
+		Env: map[string]string{
+			"FOO": "bar",
+		},
+	}
+
+	hook := &stack.LifecycleHook{Command: []string{"sh", "-c", "pwd; echo \"$FOO\"; >&2 echo warn"}}
+
+	exec := newCommandHookExecutor()
+	res := exec.Run(context.Background(), svc, "preStart", hook)
+	if res.Err != nil {
+		t.Fatalf("hook run returned error: %v", res.Err)
+	}
+
+	sawPwd := false
+	sawEnv := false
+	sawStderr := false
+	for _, entry := range res.Logs {
+		switch entry.Message {
+		case dir:
+			if entry.Stream != hookStreamStdout {
+				t.Fatalf("expected pwd log to be stdout, got %q", entry.Stream)
+			}
+			sawPwd = true
+		case "bar":
+			if entry.Stream != hookStreamStdout {
+				t.Fatalf("expected env log to be stdout, got %q", entry.Stream)
+			}
+			sawEnv = true
+		case "warn":
+			if entry.Stream != hookStreamStderr {
+				t.Fatalf("expected stderr log to be stderr, got %q", entry.Stream)
+			}
+			sawStderr = true
+		}
+	}
+
+	if !sawPwd {
+		t.Fatalf("pwd output not observed; logs=%v", res.Logs)
+	}
+	if !sawEnv {
+		t.Fatalf("env output not observed; logs=%v", res.Logs)
+	}
+	if !sawStderr {
+		t.Fatalf("stderr output not observed; logs=%v", res.Logs)
+	}
+
+	if len(res.Command) != len(hook.Command) {
+		t.Fatalf("expected command to be preserved, got %v", res.Command)
+	}
+	for i, arg := range hook.Command {
+		if res.Command[i] != arg {
+			t.Fatalf("command argument mismatch at %d: got %q want %q", i, res.Command[i], arg)
+		}
+	}
+}
+
+func TestCommandHookExecutorTimeout(t *testing.T) {
+	hook := &stack.LifecycleHook{
+		Command: []string{"sh", "-c", "sleep 1"},
+		Timeout: stack.Duration{Duration: 10 * time.Millisecond},
+	}
+
+	exec := newCommandHookExecutor()
+	start := time.Now()
+	res := exec.Run(context.Background(), &stack.Service{}, "preStop", hook)
+
+	if !res.TimedOut {
+		t.Fatalf("expected timeout, got %+v", res)
+	}
+	if !errors.Is(res.Err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded error, got %v", res.Err)
+	}
+
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("hook execution exceeded expected timeout window: %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary
- add a hook executor that runs lifecycle commands with service environment, captures output, and enforces per-hook timeouts
- integrate supervisor start and stop flows with lifecycle hooks and emit hook events for logs and failures
- cover hook execution and supervisor hook sequencing with new unit tests

## Testing
- go test ./... *(fails: missing native dependencies such as gpgme/devmapper/btrfs headers and process env fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e976d7e86483258426ac5bb003472d